### PR TITLE
Wrap ctx.Err

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -1,13 +1,13 @@
 package agent
 
 import (
-	"errors"
 	"sync"
 	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -201,7 +201,7 @@ func (s *session) heartbeat(ctx context.Context) error {
 		case <-s.closed:
 			return errSessionClosed
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while waiting to send heartbeat")
 		}
 	}
 }
@@ -228,7 +228,7 @@ func (s *session) handleSessionMessage(ctx context.Context, msg *api.SessionMess
 	case <-s.closed:
 		return errSessionClosed
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Wrap(ctx.Err(), "context done while waiting for sesssion message")
 	}
 }
 
@@ -252,7 +252,7 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 			case <-s.closed:
 				return errSessionClosed
 			case <-ctx.Done():
-				return ctx.Err()
+				return errors.Wrap(ctx.Err(), "context done while parked in log subscription exit case")
 			}
 		}
 		if err != nil {
@@ -264,7 +264,7 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 		case <-s.closed:
 			return errSessionClosed
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while waiting for log subscription")
 		}
 	}
 }
@@ -349,7 +349,7 @@ func (s *session) watch(ctx context.Context) error {
 		case <-s.closed:
 			return errSessionClosed
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while waiting for assignments")
 		}
 	}
 }
@@ -394,7 +394,7 @@ func (s *session) sendTaskStatuses(ctx context.Context, updates ...*api.UpdateTa
 	case <-s.closed:
 		return updates, ErrClosed
 	case <-ctx.Done():
-		return updates, ctx.Err()
+		return updates, errors.Wrap(ctx.Err(), "context done before sending task statuses")
 	}
 
 	client := api.NewDispatcherClient(s.conn.ClientConn)

--- a/agent/task.go
+++ b/agent/task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/equality"
 	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -47,7 +48,7 @@ func (tm *taskManager) Update(ctx context.Context, task *api.Task) error {
 	case <-tm.closed:
 		return ErrClosed
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Wrap(ctx.Err(), "context done while updating task")
 	}
 }
 

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/watch"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -572,7 +573,7 @@ func (w *worker) Subscribe(ctx context.Context, subscription *api.SubscriptionMe
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while outputing logs")
 		case <-waitCh:
 			return nil
 		}
@@ -597,7 +598,7 @@ func (w *worker) Subscribe(ctx context.Context, subscription *api.SubscriptionMe
 				go tm.Logs(ctx, *subscription.Options, publisher)
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while following logs")
 		}
 	}
 }
@@ -613,6 +614,6 @@ func (w *worker) Wait(ctx context.Context) error {
 	case <-ch:
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Wrap(ctx.Err(), "context done while waiting for worker")
 	}
 }

--- a/api/ca.pb.go
+++ b/api/ca.pb.go
@@ -241,6 +241,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -1044,7 +1045,7 @@ func (p *raftProxyCAServer) pollNewLeaderConn(ctx context.Context) (*grpc.Client
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }
@@ -1186,7 +1187,7 @@ func (p *raftProxyNodeCAServer) pollNewLeaderConn(ctx context.Context) (*grpc.Cl
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -23,6 +23,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -5917,7 +5918,7 @@ func (p *raftProxyControlServer) pollNewLeaderConn(ctx context.Context) (*grpc.C
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -28,6 +28,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -1660,7 +1661,7 @@ func (p *raftProxyDispatcherServer) pollNewLeaderConn(ctx context.Context) (*grp
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/health.pb.go
+++ b/api/health.pb.go
@@ -21,6 +21,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -344,7 +345,7 @@ func (p *raftProxyHealthServer) pollNewLeaderConn(ctx context.Context) (*grpc.Cl
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -24,6 +24,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -1331,7 +1332,7 @@ func (p *raftProxyLogsServer) pollNewLeaderConn(ctx context.Context) (*grpc.Clie
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }
@@ -1454,7 +1455,7 @@ func (p *raftProxyLogBrokerServer) pollNewLeaderConn(ctx context.Context) (*grpc
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -25,6 +25,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -1707,7 +1708,7 @@ func (p *raftProxyRaftServer) pollNewLeaderConn(ctx context.Context) (*grpc.Clie
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }
@@ -1906,7 +1907,7 @@ func (p *raftProxyRaftMembershipServer) pollNewLeaderConn(ctx context.Context) (
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -23,6 +23,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -461,7 +462,7 @@ func (p *raftProxyResourceAllocatorServer) pollNewLeaderConn(ctx context.Context
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/api/watch.pb.go
+++ b/api/watch.pb.go
@@ -23,6 +23,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -2101,7 +2102,7 @@ func (p *raftProxyWatchServer) pollNewLeaderConn(ctx context.Context) (*grpc.Cli
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }

--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -270,7 +270,7 @@ func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWrit
 		select {
 		case <-time.After(config.RetryInterval):
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, errors.Wrap(ctx.Err(), "context done while trying to get remote signed certificate")
 		}
 	}
 	if err != nil {
@@ -322,7 +322,7 @@ func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWrit
 		select {
 		case <-time.After(config.RetryInterval):
 		case <-ctx.Done():
-			return nil, nil, ctx.Err()
+			return nil, nil, errors.Wrap(ctx.Err(), "context done while trying to get KEK update")
 		}
 	}
 	if err != nil {

--- a/ca/config.go
+++ b/ca/config.go
@@ -332,7 +332,7 @@ func DownloadRootCA(ctx context.Context, paths CertPaths, token string, connBrok
 		select {
 		case <-time.After(GetCertRetryInterval):
 		case <-ctx.Done():
-			return RootCA{}, ctx.Err()
+			return RootCA{}, errors.Wrap(ctx.Err(), "context done while trying to get remote CA")
 		}
 	}
 	if err != nil {

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -98,7 +98,7 @@ func (c *MutableTLSCreds) ClientHandshake(ctx context.Context, addr string, rawC
 	select {
 	case err = <-errChannel:
 	case <-ctx.Done():
-		err = ctx.Err()
+		err = errors.Wrap(ctx.Err(), "context canceled while waiting for client handshake")
 	}
 	if err != nil {
 		rawConn.Close()

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -224,7 +225,7 @@ func (s *subscription) watch(ch <-chan events.Event) error {
 		var t *api.Task
 		select {
 		case <-s.ctx.Done():
-			return s.ctx.Err()
+			return errors.Wrap(s.ctx.Err(), "context done while watching log subscriptions")
 		case event := <-ch:
 			switch v := event.(type) {
 			case api.EventCreateTask:

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -332,7 +332,7 @@ func (n *Node) SetAddr(ctx context.Context, addr string) error {
 				isLeader = true
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done wile waiting for this node to become a leader")
 		}
 	}
 
@@ -1237,7 +1237,7 @@ func (n *Node) TransferLeadership(ctx context.Context) error {
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while waiting to transfer leadership")
 		case <-ticker.C:
 		}
 	}
@@ -1517,7 +1517,7 @@ func (n *Node) LeaderConn(ctx context.Context) (*grpc.ClientConn, error) {
 				return nil, err
 			}
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context done while waiting for connection to cluster leader")
 		}
 	}
 }
@@ -1826,7 +1826,7 @@ func (n *Node) processInternalRaftRequest(ctx context.Context, r *api.InternalRa
 		// if channel is closed, wait item was canceled, otherwise it was triggered
 		x, ok := <-ch
 		if !ok {
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context done while processing internal raft request")
 		}
 		return x.(proto.Message), nil
 	}
@@ -1857,7 +1857,7 @@ func (n *Node) configure(ctx context.Context, cc raftpb.ConfChange) error {
 		return nil
 	case <-ctx.Done():
 		n.wait.cancel(cc.ID)
-		return ctx.Err()
+		return errors.Wrap(ctx.Err(), "context done while waiting for raft configuration change to go through")
 	}
 }
 

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -75,13 +75,13 @@ func (p *peer) send(m raftpb.Message) (err error) {
 	}()
 	select {
 	case <-p.ctx.Done():
-		return p.ctx.Err()
+		return errors.Wrap(p.ctx.Err(), "peer context done before trying to send a message")
 	default:
 	}
 	select {
 	case p.msgc <- m:
 	case <-p.ctx.Done():
-		return p.ctx.Err()
+		return errors.Wrap(p.ctx.Err(), "peer context done while trying to send a message")
 	default:
 		p.tr.config.ReportUnreachable(p.id)
 		return errors.Errorf("peer is unreachable")
@@ -314,7 +314,7 @@ func (p *peer) drain() error {
 				return errors.Wrap(err, "send drain message")
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "sending drain message timed out")
 		}
 	}
 }

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -139,7 +139,7 @@ func (t *Transport) Send(m raftpb.Message) error {
 		// to not block sender
 		case t.unknownc <- m:
 		case <-t.ctx.Done():
-			return t.ctx.Err()
+			return errors.Wrap(t.ctx.Err(), "context done while sending raft message")
 		default:
 			return errors.New("unknown messages queue is full")
 		}

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -48,7 +49,7 @@ func WaitForLeader(ctx context.Context, n *Node) error {
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while waiting for leader")
 		}
 		_, err = n.Leader()
 	}
@@ -78,7 +79,7 @@ func WaitForCluster(ctx context.Context, n *Node) (cluster *api.Cluster, err err
 		case e := <-watch:
 			cluster = e.(api.EventCreateCluster).Cluster
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context done while waiting for cluster")
 		}
 	}
 

--- a/manager/watchapi/watch.go
+++ b/manager/watchapi/watch.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -44,9 +45,9 @@ func (s *Server) Watch(request *api.WatchRequest, stream api.Watch_WatchServer) 
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "context done while watching for events")
 		case <-pctx.Done():
-			return pctx.Err()
+			return errors.Wrap(pctx.Err(), "server context done while watching for events")
 		case event := <-watch:
 			if commitEvent, ok := event.(state.EventCommit); ok && len(events) > 0 {
 				if err := stream.Send(&api.WatchMessage{Events: events, Version: commitEvent.Version}); err != nil {

--- a/protobuf/plugin/raftproxy/raftproxy.go
+++ b/protobuf/plugin/raftproxy/raftproxy.go
@@ -350,7 +350,7 @@ func (g *raftProxyGen) genPollNewLeaderConn(s *descriptor.ServiceDescriptorProto
 				}
 				return conn, nil
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 			}
 		}
 	}`)
@@ -381,4 +381,6 @@ func (g *raftProxyGen) GenerateImports(file *generator.FileDescriptor) {
 	g.gen.P("import transport \"google.golang.org/grpc/transport\"")
 	// don't conflict with import added by ptypes
 	g.gen.P("import rafttime \"time\"")
+	// import errors to annotate context deadline exceeded errors
+	g.gen.P("import \"github.com/pkg/errors\"")
 }

--- a/protobuf/plugin/raftproxy/test/service.pb.go
+++ b/protobuf/plugin/raftproxy/test/service.pb.go
@@ -36,6 +36,7 @@ import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
+import "github.com/pkg/errors"
 
 import strings "strings"
 import reflect "reflect"
@@ -1031,7 +1032,7 @@ func (p *raftProxyRouteGuideServer) pollNewLeaderConn(ctx context.Context) (*grp
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }
@@ -1314,7 +1315,7 @@ func (p *raftProxyHealthServer) pollNewLeaderConn(ctx context.Context) (*grpc.Cl
 			}
 			return conn, nil
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.Wrap(ctx.Err(), "context canceled while waiting for new leader connection")
 		}
 	}
 }


### PR DESCRIPTION
In locations where the context is canceled, instead of returning a completely unhelpful ctx.Err, add some annotation indicating what was happening when the context was canceled.

Includes an update to generated raftproxy code.