### PR TITLE
[WIP] Bump hashicorp deps

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -48,7 +48,7 @@ github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/fernet/fernet-go 9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go v1.0.20
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
-github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
+github.com/hashicorp/go-memdb dd4dbb7cbc982b021ac8d7db55d9553dee3eeeda # v1.0.3
 github.com/hashicorp/golang-lru 7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c # v0.5.1
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/phayes/permbits f7e3ac5e859d0b919c5068d581cc4c5d4f4f9bc5

--- a/vendor.conf
+++ b/vendor.conf
@@ -49,7 +49,7 @@ github.com/fernet/fernet-go 9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go v1.0.20
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/go-memdb dd4dbb7cbc982b021ac8d7db55d9553dee3eeeda # v1.0.3
-github.com/hashicorp/golang-lru 7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c # v0.5.1
+github.com/hashicorp/golang-lru 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/phayes/permbits f7e3ac5e859d0b919c5068d581cc4c5d4f4f9bc5
 code.cloudfoundry.org/clock 02e53af36e6c978af692887ed449b74026d76fec

--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,8 @@ github.com/cloudflare/cfssl 1.3.2
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/fernet/fernet-go 9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go v1.0.20
-github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+# WIP WIP WIP; https://github.com/tonistiigi/go-immutable-radix/pull/1
+github.com/hashicorp/go-immutable-radix update_seek https://github.com/thaJeztah/go-immutable-radix.git
 github.com/hashicorp/go-memdb dd4dbb7cbc982b021ac8d7db55d9553dee3eeeda # v1.0.3
 github.com/hashicorp/golang-lru 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75

--- a/vendor/github.com/hashicorp/go-immutable-radix/README.md
+++ b/vendor/github.com/hashicorp/go-immutable-radix/README.md
@@ -39,3 +39,28 @@ if string(m) != "foo" {
 }
 ```
 
+Here is an example of performing a range scan of the keys.
+
+```go
+// Create a tree
+r := iradix.New()
+r, _, _ = r.Insert([]byte("001"), 1)
+r, _, _ = r.Insert([]byte("002"), 2)
+r, _, _ = r.Insert([]byte("005"), 5)
+r, _, _ = r.Insert([]byte("010"), 10)
+r, _, _ = r.Insert([]byte("100"), 10)
+
+// Range scan over the keys that sort lexicographically between [003, 050)
+it := r.Root().Iterator()
+it.SeekLowerBound([]byte("003"))
+for key, _, ok := it.Next(); ok; key, _, ok = it.Next() {
+  if key >= "050" {
+      break
+  }
+  fmt.Println(key)
+}
+// Output:
+//  005
+//  010
+```
+

--- a/vendor/github.com/hashicorp/go-immutable-radix/go.mod
+++ b/vendor/github.com/hashicorp/go-immutable-radix/go.mod
@@ -1,0 +1,6 @@
+module github.com/hashicorp/go-immutable-radix
+
+require (
+	github.com/hashicorp/go-uuid v1.0.0
+	github.com/hashicorp/golang-lru v0.5.0
+)

--- a/vendor/github.com/hashicorp/go-immutable-radix/iradix.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/iradix.go
@@ -338,6 +338,11 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if !n.isLeaf() {
 			return nil, nil
 		}
+		// Copy the pointer in case we are in a transaction that already
+		// modified this node since the node will be reused. Any changes
+		// made to the node will not affect returning the original leaf
+		// value.
+		oldLeaf := n.leaf
 
 		// Remove the leaf node
 		nc := t.writeNode(n, true)
@@ -347,7 +352,7 @@ func (t *Txn) delete(parent, n *Node, search []byte) (*Node, *leafNode) {
 		if n != t.root && len(nc.edges) == 1 {
 			t.mergeChild(nc)
 		}
-		return nc, n.leaf
+		return nc, oldLeaf
 	}
 
 	// Look for an edge

--- a/vendor/github.com/hashicorp/go-immutable-radix/iter.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/iter.go
@@ -1,6 +1,8 @@
 package iradix
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // Iterator is used to iterate over a set of nodes
 // in pre-order
@@ -51,6 +53,101 @@ func (i *Iterator) SeekPrefixWatch(prefix []byte) (watch <-chan struct{}) {
 // SeekPrefix is used to seek the iterator to a given prefix
 func (i *Iterator) SeekPrefix(prefix []byte) {
 	i.SeekPrefixWatch(prefix)
+}
+
+func (i *Iterator) recurseMin(n *Node) *Node {
+	// Traverse to the minimum child
+	if n.leaf != nil {
+		return n
+	}
+	if len(n.edges) > 0 {
+		// Add all the other edges to the stack (the min node will be added as
+		// we recurse)
+		i.stack = append(i.stack, n.edges[1:])
+		return i.recurseMin(n.edges[0].node)
+	}
+	// Shouldn't be possible
+	return nil
+}
+
+// SeekLowerBound is used to seek the iterator to the smallest key that is
+// greater or equal to the given key. There is no watch variant as it's hard to
+// predict based on the radix structure which node(s) changes might affect the
+// result.
+func (i *Iterator) SeekLowerBound(key []byte) {
+	// Wipe the stack. Unlike Prefix iteration, we need to build the stack as we
+	// go because we need only a subset of edges of many nodes in the path to the
+	// leaf with the lower bound.
+	i.stack = []edges{}
+	n := i.node
+	search := key
+
+	found := func(n *Node) {
+		i.node = n
+		i.stack = append(i.stack, edges{edge{node: n}})
+	}
+
+	for {
+		// Compare current prefix with the search key's same-length prefix.
+		var prefixCmp int
+		if len(n.prefix) < len(search) {
+			prefixCmp = bytes.Compare(n.prefix, search[0:len(n.prefix)])
+		} else {
+			prefixCmp = bytes.Compare(n.prefix, search)
+		}
+
+		if prefixCmp > 0 {
+			// Prefix is larger, that means the lower bound is greater than the search
+			// and from now on we need to follow the minimum path to the smallest
+			// leaf under this subtree.
+			n = i.recurseMin(n)
+			if n != nil {
+				found(n)
+			}
+			return
+		}
+
+		if prefixCmp < 0 {
+			// Prefix is smaller than search prefix, that means there is no lower
+			// bound
+			i.node = nil
+			return
+		}
+
+		// Prefix is equal, we are still heading for an exact match. If this is a
+		// leaf we're done.
+		if n.leaf != nil {
+			if bytes.Compare(n.leaf.key, key) < 0 {
+				i.node = nil
+				return
+			}
+			found(n)
+			return
+		}
+
+		// Consume the search prefix
+		if len(n.prefix) > len(search) {
+			search = []byte{}
+		} else {
+			search = search[len(n.prefix):]
+		}
+
+		// Otherwise, take the lower bound next edge.
+		idx, lbNode := n.getLowerBoundEdge(search[0])
+		if lbNode == nil {
+			i.node = nil
+			return
+		}
+
+		// Create stack edges for the all strictly higher edges in this node.
+		if idx+1 < len(n.edges) {
+			i.stack = append(i.stack, n.edges[idx+1:])
+		}
+
+		i.node = lbNode
+		// Recurse
+		n = lbNode
+	}
 }
 
 // Next returns the next node in order

--- a/vendor/github.com/hashicorp/go-immutable-radix/node.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/node.go
@@ -79,6 +79,18 @@ func (n *Node) getEdge(label byte) (int, *Node) {
 	return -1, nil
 }
 
+func (n *Node) getLowerBoundEdge(label byte) (int, *Node) {
+	num := len(n.edges)
+	idx := sort.Search(num, func(i int) bool {
+		return n.edges[i].label >= label
+	})
+	// we want lower bound behavior so return even if it's not an exact match
+	if idx < num {
+		return idx, n.edges[idx].node
+	}
+	return -1, nil
+}
+
 func (n *Node) delEdge(label byte) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {

--- a/vendor/github.com/hashicorp/go-memdb/README.md
+++ b/vendor/github.com/hashicorp/go-memdb/README.md
@@ -1,9 +1,9 @@
-# go-memdb
+# go-memdb [![CircleCI](https://circleci.com/gh/hashicorp/go-memdb/tree/master.svg?style=svg)](https://circleci.com/gh/hashicorp/go-memdb/tree/master)
 
 Provides the `memdb` package that implements a simple in-memory database
 built on immutable radix trees. The database provides Atomicity, Consistency
 and Isolation from ACID. Being that it is in-memory, it does not provide durability.
-The database is instantiated with a schema that specifies the tables and indicies
+The database is instantiated with a schema that specifies the tables and indices
 that exist and allows transactions to be executed.
 
 The database provides the following:
@@ -19,8 +19,13 @@ The database provides the following:
 
 * Rich Indexing - Tables can support any number of indexes, which can be simple like
   a single field index, or more advanced compound field indexes. Certain types like
-  UUID can be efficiently compressed from strings into byte indexes for reduces
+  UUID can be efficiently compressed from strings into byte indexes for reduced
   storage requirements.
+
+* Watches - Callers can populate a watch set as part of a query, which can be used to
+  detect when a modification has been made to the database which affects the query
+  results. This lets callers easily watch for changes in the database in a very general
+  way.
 
 For the underlying immutable radix trees, see [go-immutable-radix](https://github.com/hashicorp/go-immutable-radix).
 

--- a/vendor/github.com/hashicorp/go-memdb/filter.go
+++ b/vendor/github.com/hashicorp/go-memdb/filter.go
@@ -1,0 +1,33 @@
+package memdb
+
+// FilterFunc is a function that takes the results of an iterator and returns
+// whether the result should be filtered out.
+type FilterFunc func(interface{}) bool
+
+// FilterIterator is used to wrap a ResultIterator and apply a filter over it.
+type FilterIterator struct {
+	// filter is the filter function applied over the base iterator.
+	filter FilterFunc
+
+	// iter is the iterator that is being wrapped.
+	iter ResultIterator
+}
+
+func NewFilterIterator(wrap ResultIterator, filter FilterFunc) *FilterIterator {
+	return &FilterIterator{
+		filter: filter,
+		iter:   wrap,
+	}
+}
+
+// WatchCh returns the watch channel of the wrapped iterator.
+func (f *FilterIterator) WatchCh() <-chan struct{} { return f.iter.WatchCh() }
+
+// Next returns the next non-filtered result from the wrapped iterator
+func (f *FilterIterator) Next() interface{} {
+	for {
+		if value := f.iter.Next(); value == nil || !f.filter(value) {
+			return value
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/go-memdb/go.mod
+++ b/vendor/github.com/hashicorp/go-memdb/go.mod
@@ -1,0 +1,5 @@
+module github.com/hashicorp/go-memdb
+
+go 1.12
+
+require github.com/hashicorp/go-immutable-radix v1.1.0

--- a/vendor/github.com/hashicorp/go-memdb/index.go
+++ b/vendor/github.com/hashicorp/go-memdb/index.go
@@ -1,41 +1,54 @@
 package memdb
 
 import (
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 )
 
-// Indexer is an interface used for defining indexes
+// Indexer is an interface used for defining indexes. Indexes are used
+// for efficient lookup of objects in a MemDB table. An Indexer must also
+// implement one of SingleIndexer or MultiIndexer.
+//
+// Indexers are primarily responsible for returning the lookup key as
+// a byte slice. The byte slice is the key data in the underlying data storage.
 type Indexer interface {
-	// ExactFromArgs is used to build an exact index lookup
-	// based on arguments
+	// FromArgs is called to build the exact index key from a list of arguments.
 	FromArgs(args ...interface{}) ([]byte, error)
 }
 
-// SingleIndexer is an interface used for defining indexes
-// generating a single entry per object
+// SingleIndexer is an interface used for defining indexes that generate a
+// single value per object
 type SingleIndexer interface {
-	// FromObject is used to extract an index value from an
-	// object or to indicate that the index value is missing.
+	// FromObject extracts the index value from an object. The return values
+	// are whether the index value was found, the index value, and any error
+	// while extracting the index value, respectively.
 	FromObject(raw interface{}) (bool, []byte, error)
 }
 
-// MultiIndexer is an interface used for defining indexes
-// generating multiple entries per object
+// MultiIndexer is an interface used for defining indexes that generate
+// multiple values per object. Each value is stored as a seperate index
+// pointing to the same object.
+//
+// For example, an index that extracts the first and last name of a person
+// and allows lookup based on eitherd would be a MultiIndexer. The FromObject
+// of this example would split the first and last name and return both as
+// values.
 type MultiIndexer interface {
-	// FromObject is used to extract index values from an
-	// object or to indicate that the index value is missing.
+	// FromObject extracts index values from an object. The return values
+	// are the same as a SingleIndexer except there can be multiple index
+	// values.
 	FromObject(raw interface{}) (bool, [][]byte, error)
 }
 
-// PrefixIndexer can optionally be implemented for any
-// indexes that support prefix based iteration. This may
-// not apply to all indexes.
+// PrefixIndexer is an optional interface on top of an Indexer that allows
+// indexes to support prefix-based iteration.
 type PrefixIndexer interface {
-	// PrefixFromArgs returns a prefix that should be used
-	// for scanning based on the arguments
+	// PrefixFromArgs is the same as FromArgs for an Indexer except that
+	// the index value returned should return all prefix-matched values.
 	PrefixFromArgs(args ...interface{}) ([]byte, error)
 }
 
@@ -51,9 +64,16 @@ func (s *StringFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
 	v = reflect.Indirect(v) // Dereference the pointer if any
 
 	fv := v.FieldByName(s.Field)
-	if !fv.IsValid() {
+	isPtr := fv.Kind() == reflect.Ptr
+	fv = reflect.Indirect(fv)
+	if !isPtr && !fv.IsValid() {
 		return false, nil,
-			fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+			fmt.Errorf("field '%s' for %#v is invalid %v ", s.Field, obj, isPtr)
+	}
+
+	if isPtr && !fv.IsValid() {
+		val := ""
+		return true, []byte(val), nil
 	}
 
 	val := fv.String()
@@ -100,8 +120,9 @@ func (s *StringFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 	return val, nil
 }
 
-// StringSliceFieldIndex is used to extract a field from an object
-// using reflection and builds an index on that field.
+// StringSliceFieldIndex builds an index from a field on an object that is a
+// string slice ([]string). Each value within the string slice can be used for
+// lookup.
 type StringSliceFieldIndex struct {
 	Field     string
 	Lowercase bool
@@ -171,6 +192,240 @@ func (s *StringSliceFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, err
 		return val[:n-1], nil
 	}
 	return val, nil
+}
+
+// StringMapFieldIndex is used to extract a field of type map[string]string
+// from an object using reflection and builds an index on that field.
+//
+// Note that although FromArgs in theory supports using either one or
+// two arguments, there is a bug: FromObject only creates an index
+// using key/value, and does not also create an index using key. This
+// means a lookup using one argument will never actually work.
+//
+// It is currently left as-is to prevent backwards compatibility
+// issues.
+//
+// TODO: Fix this in the next major bump.
+type StringMapFieldIndex struct {
+	Field     string
+	Lowercase bool
+}
+
+var MapType = reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf("")).Kind()
+
+func (s *StringMapFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(s.Field)
+	if !fv.IsValid() {
+		return false, nil, fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+	}
+
+	if fv.Kind() != MapType {
+		return false, nil, fmt.Errorf("field '%s' is not a map[string]string", s.Field)
+	}
+
+	length := fv.Len()
+	vals := make([][]byte, 0, length)
+	for _, key := range fv.MapKeys() {
+		k := key.String()
+		if k == "" {
+			continue
+		}
+		val := fv.MapIndex(key).String()
+
+		if s.Lowercase {
+			k = strings.ToLower(k)
+			val = strings.ToLower(val)
+		}
+
+		// Add the null character as a terminator
+		k += "\x00" + val + "\x00"
+
+		vals = append(vals, []byte(k))
+	}
+	if len(vals) == 0 {
+		return false, nil, nil
+	}
+	return true, vals, nil
+}
+
+// WARNING: Because of a bug in FromObject, this function will never return
+// a value when using the single-argument version.
+func (s *StringMapFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) > 2 || len(args) == 0 {
+		return nil, fmt.Errorf("must provide one or two arguments")
+	}
+	key, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a string: %#v", args[0])
+	}
+	if s.Lowercase {
+		key = strings.ToLower(key)
+	}
+	// Add the null character as a terminator
+	key += "\x00"
+
+	if len(args) == 2 {
+		val, ok := args[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("argument must be a string: %#v", args[1])
+		}
+		if s.Lowercase {
+			val = strings.ToLower(val)
+		}
+		// Add the null character as a terminator
+		key += val + "\x00"
+	}
+
+	return []byte(key), nil
+}
+
+// IntFieldIndex is used to extract an int field from an object using
+// reflection and builds an index on that field.
+type IntFieldIndex struct {
+	Field string
+}
+
+func (i *IntFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(i.Field)
+	if !fv.IsValid() {
+		return false, nil,
+			fmt.Errorf("field '%s' for %#v is invalid", i.Field, obj)
+	}
+
+	// Check the type
+	k := fv.Kind()
+	size, ok := IsIntType(k)
+	if !ok {
+		return false, nil, fmt.Errorf("field %q is of type %v; want an int", i.Field, k)
+	}
+
+	// Get the value and encode it
+	val := fv.Int()
+	buf := make([]byte, size)
+	binary.PutVarint(buf, val)
+
+	return true, buf, nil
+}
+
+func (i *IntFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+
+	v := reflect.ValueOf(args[0])
+	if !v.IsValid() {
+		return nil, fmt.Errorf("%#v is invalid", args[0])
+	}
+
+	k := v.Kind()
+	size, ok := IsIntType(k)
+	if !ok {
+		return nil, fmt.Errorf("arg is of type %v; want a int", k)
+	}
+
+	val := v.Int()
+	buf := make([]byte, size)
+	binary.PutVarint(buf, val)
+
+	return buf, nil
+}
+
+// IsIntType returns whether the passed type is a type of int and the number
+// of bytes needed to encode the type.
+func IsIntType(k reflect.Kind) (size int, okay bool) {
+	switch k {
+	case reflect.Int:
+		return binary.MaxVarintLen64, true
+	case reflect.Int8:
+		return 2, true
+	case reflect.Int16:
+		return binary.MaxVarintLen16, true
+	case reflect.Int32:
+		return binary.MaxVarintLen32, true
+	case reflect.Int64:
+		return binary.MaxVarintLen64, true
+	default:
+		return 0, false
+	}
+}
+
+// UintFieldIndex is used to extract a uint field from an object using
+// reflection and builds an index on that field.
+type UintFieldIndex struct {
+	Field string
+}
+
+func (u *UintFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(u.Field)
+	if !fv.IsValid() {
+		return false, nil,
+			fmt.Errorf("field '%s' for %#v is invalid", u.Field, obj)
+	}
+
+	// Check the type
+	k := fv.Kind()
+	size, ok := IsUintType(k)
+	if !ok {
+		return false, nil, fmt.Errorf("field %q is of type %v; want a uint", u.Field, k)
+	}
+
+	// Get the value and encode it
+	val := fv.Uint()
+	buf := make([]byte, size)
+	binary.PutUvarint(buf, val)
+
+	return true, buf, nil
+}
+
+func (u *UintFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+
+	v := reflect.ValueOf(args[0])
+	if !v.IsValid() {
+		return nil, fmt.Errorf("%#v is invalid", args[0])
+	}
+
+	k := v.Kind()
+	size, ok := IsUintType(k)
+	if !ok {
+		return nil, fmt.Errorf("arg is of type %v; want a uint", k)
+	}
+
+	val := v.Uint()
+	buf := make([]byte, size)
+	binary.PutUvarint(buf, val)
+
+	return buf, nil
+}
+
+// IsUintType returns whether the passed type is a type of uint and the number
+// of bytes needed to encode the type.
+func IsUintType(k reflect.Kind) (size int, okay bool) {
+	switch k {
+	case reflect.Uint:
+		return binary.MaxVarintLen64, true
+	case reflect.Uint8:
+		return 2, true
+	case reflect.Uint16:
+		return binary.MaxVarintLen16, true
+	case reflect.Uint32:
+		return binary.MaxVarintLen32, true
+	case reflect.Uint64:
+		return binary.MaxVarintLen64, true
+	default:
+		return 0, false
+	}
 }
 
 // UUIDFieldIndex is used to extract a field from an object
@@ -378,7 +633,7 @@ func (c *CompoundIndex) FromObject(raw interface{}) (bool, []byte, error) {
 
 func (c *CompoundIndex) FromArgs(args ...interface{}) ([]byte, error) {
 	if len(args) != len(c.Indexes) {
-		return nil, fmt.Errorf("less arguments than index fields")
+		return nil, fmt.Errorf("non-equivalent argument count and index fields")
 	}
 	var out []byte
 	for i, arg := range args {
@@ -414,6 +669,180 @@ func (c *CompoundIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 			}
 			out = append(out, val...)
 		}
+	}
+	return out, nil
+}
+
+// CompoundMultiIndex is used to build an index using multiple
+// sub-indexes.
+//
+// Unlike CompoundIndex, CompoundMultiIndex can have both
+// SingleIndexer and MultiIndexer sub-indexers. However, each
+// MultiIndexer adds considerable overhead/complexity in terms of
+// the number of indexes created under-the-hood. It is not suggested
+// to use more than one or two, if possible.
+//
+// Another change from CompoundIndexer is that if AllowMissing is
+// set, not only is it valid to have empty index fields, but it will
+// still create index values up to the first empty index. This means
+// that if you have a value with an empty field, rather than using a
+// prefix for lookup, you can simply pass in less arguments. As an
+// example, if {Foo, Bar} is indexed but Bar is missing for a value
+// and AllowMissing is set, an index will still be created for {Foo}
+// and it is valid to do a lookup passing in only Foo as an argument.
+// Note that the ordering isn't guaranteed -- it's last-insert wins,
+// but this is true if you have two objects that have the same
+// indexes not using AllowMissing anyways.
+//
+// Because StringMapFieldIndexers can take a varying number of args,
+// it is currently a requirement that whenever it is used, two
+// arguments must _always_ be provided for it. In theory we only
+// need one, except a bug in that indexer means the single-argument
+// version will never work. You can leave the second argument nil,
+// but it will never produce a value. We support this for whenever
+// that bug is fixed, likely in a next major version bump.
+//
+// Prefix-based indexing is not currently supported.
+type CompoundMultiIndex struct {
+	Indexes []Indexer
+
+	// AllowMissing results in an index based on only the indexers
+	// that return data. If true, you may end up with 2/3 columns
+	// indexed which might be useful for an index scan. Otherwise,
+	// CompoundMultiIndex requires all indexers to be satisfied.
+	AllowMissing bool
+}
+
+func (c *CompoundMultiIndex) FromObject(raw interface{}) (bool, [][]byte, error) {
+	// At each entry, builder is storing the results from the next index
+	builder := make([][][]byte, 0, len(c.Indexes))
+	// Start with something higher to avoid resizing if possible
+	out := make([][]byte, 0, len(c.Indexes)^3)
+
+forloop:
+	// This loop goes through each indexer and adds the value(s) provided to the next
+	// entry in the slice. We can then later walk it like a tree to construct the indices.
+	for i, idxRaw := range c.Indexes {
+		switch idx := idxRaw.(type) {
+		case SingleIndexer:
+			ok, val, err := idx.FromObject(raw)
+			if err != nil {
+				return false, nil, fmt.Errorf("single sub-index %d error: %v", i, err)
+			}
+			if !ok {
+				if c.AllowMissing {
+					break forloop
+				} else {
+					return false, nil, nil
+				}
+			}
+			builder = append(builder, [][]byte{val})
+
+		case MultiIndexer:
+			ok, vals, err := idx.FromObject(raw)
+			if err != nil {
+				return false, nil, fmt.Errorf("multi sub-index %d error: %v", i, err)
+			}
+			if !ok {
+				if c.AllowMissing {
+					break forloop
+				} else {
+					return false, nil, nil
+				}
+			}
+
+			// Add each of the new values to each of the old values
+			builder = append(builder, vals)
+
+		default:
+			return false, nil, fmt.Errorf("sub-index %d does not satisfy either SingleIndexer or MultiIndexer", i)
+		}
+	}
+
+	// We are walking through the builder slice essentially in a depth-first fashion,
+	// building the prefix and leaves as we go. If AllowMissing is false, we only insert
+	// these full paths to leaves. Otherwise, we also insert each prefix along the way.
+	// This allows for lookup in FromArgs when AllowMissing is true that does not contain
+	// the full set of arguments. e.g. for {Foo, Bar} where an object has only the Foo
+	// field specified as "abc", it is valid to call FromArgs with just "abc".
+	var walkVals func([]byte, int)
+	walkVals = func(currPrefix []byte, depth int) {
+		if depth == len(builder)-1 {
+			// These are the "leaves", so append directly
+			for _, v := range builder[depth] {
+				out = append(out, append(currPrefix, v...))
+			}
+			return
+		}
+		for _, v := range builder[depth] {
+			nextPrefix := append(currPrefix, v...)
+			if c.AllowMissing {
+				out = append(out, nextPrefix)
+			}
+			walkVals(nextPrefix, depth+1)
+		}
+	}
+
+	walkVals(nil, 0)
+
+	return true, out, nil
+}
+
+func (c *CompoundMultiIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	var stringMapCount int
+	var argCount int
+	for _, index := range c.Indexes {
+		if argCount >= len(args) {
+			break
+		}
+		if _, ok := index.(*StringMapFieldIndex); ok {
+			// We require pairs for StringMapFieldIndex, but only got one
+			if argCount+1 >= len(args) {
+				return nil, errors.New("invalid number of arguments")
+			}
+			stringMapCount++
+			argCount += 2
+		} else {
+			argCount++
+		}
+	}
+	argCount = 0
+
+	switch c.AllowMissing {
+	case true:
+		if len(args) > len(c.Indexes)+stringMapCount {
+			return nil, errors.New("too many arguments")
+		}
+
+	default:
+		if len(args) != len(c.Indexes)+stringMapCount {
+			return nil, errors.New("number of arguments does not equal number of indexers")
+		}
+	}
+
+	var out []byte
+	var val []byte
+	var err error
+	for i, idx := range c.Indexes {
+		if argCount >= len(args) {
+			// We're done; should only hit this if AllowMissing
+			break
+		}
+		if _, ok := idx.(*StringMapFieldIndex); ok {
+			if args[argCount+1] == nil {
+				val, err = idx.FromArgs(args[argCount])
+			} else {
+				val, err = idx.FromArgs(args[argCount : argCount+2]...)
+			}
+			argCount += 2
+		} else {
+			val, err = idx.FromArgs(args[argCount])
+			argCount++
+		}
+		if err != nil {
+			return nil, fmt.Errorf("sub-index %d error: %v", i, err)
+		}
+		out = append(out, val...)
 	}
 	return out, nil
 }

--- a/vendor/github.com/hashicorp/go-memdb/schema.go
+++ b/vendor/github.com/hashicorp/go-memdb/schema.go
@@ -2,33 +2,47 @@ package memdb
 
 import "fmt"
 
-// DBSchema contains the full database schema used for MemDB
+// DBSchema is the schema to use for the full database with a MemDB instance.
+//
+// MemDB will require a valid schema. Schema validation can be tested using
+// the Validate function. Calling this function is recommended in unit tests.
 type DBSchema struct {
+	// Tables is the set of tables within this database. The key is the
+	// table name and must match the Name in TableSchema.
 	Tables map[string]*TableSchema
 }
 
-// Validate is used to validate the database schema
+// Validate validates the schema.
 func (s *DBSchema) Validate() error {
 	if s == nil {
-		return fmt.Errorf("missing schema")
+		return fmt.Errorf("schema is nil")
 	}
+
 	if len(s.Tables) == 0 {
-		return fmt.Errorf("no tables defined")
+		return fmt.Errorf("schema has no tables defined")
 	}
+
 	for name, table := range s.Tables {
 		if name != table.Name {
 			return fmt.Errorf("table name mis-match for '%s'", name)
 		}
+
 		if err := table.Validate(); err != nil {
-			return err
+			return fmt.Errorf("table %q: %s", name, err)
 		}
 	}
+
 	return nil
 }
 
-// TableSchema contains the schema for a single table
+// TableSchema is the schema for a single table.
 type TableSchema struct {
-	Name    string
+	// Name of the table. This must match the key in the Tables map in DBSchema.
+	Name string
+
+	// Indexes is the set of indexes for querying this table. The key
+	// is a unique name for the index and must match the Name in the
+	// IndexSchema.
 	Indexes map[string]*IndexSchema
 }
 
@@ -37,35 +51,50 @@ func (s *TableSchema) Validate() error {
 	if s.Name == "" {
 		return fmt.Errorf("missing table name")
 	}
+
 	if len(s.Indexes) == 0 {
-		return fmt.Errorf("missing table schemas for '%s'", s.Name)
+		return fmt.Errorf("missing table indexes for '%s'", s.Name)
 	}
+
 	if _, ok := s.Indexes["id"]; !ok {
 		return fmt.Errorf("must have id index")
 	}
+
 	if !s.Indexes["id"].Unique {
 		return fmt.Errorf("id index must be unique")
 	}
+
 	if _, ok := s.Indexes["id"].Indexer.(SingleIndexer); !ok {
 		return fmt.Errorf("id index must be a SingleIndexer")
 	}
+
 	for name, index := range s.Indexes {
 		if name != index.Name {
 			return fmt.Errorf("index name mis-match for '%s'", name)
 		}
+
 		if err := index.Validate(); err != nil {
-			return err
+			return fmt.Errorf("index %q: %s", name, err)
 		}
 	}
+
 	return nil
 }
 
-// IndexSchema contains the schema for an index
+// IndexSchema is the schema for an index. An index defines how a table is
+// queried.
 type IndexSchema struct {
-	Name         string
+	// Name of the index. This must be unique among a tables set of indexes.
+	// This must match the key in the map of Indexes for a TableSchema.
+	Name string
+
+	// AllowMissing if true ignores this index if it doesn't produce a
+	// value. For example, an index that extracts a field that doesn't
+	// exist from a structure.
 	AllowMissing bool
-	Unique       bool
-	Indexer      Indexer
+
+	Unique  bool
+	Indexer Indexer
 }
 
 func (s *IndexSchema) Validate() error {

--- a/vendor/github.com/hashicorp/go-memdb/watch.go
+++ b/vendor/github.com/hashicorp/go-memdb/watch.go
@@ -1,0 +1,129 @@
+package memdb
+
+import (
+	"context"
+	"time"
+)
+
+// WatchSet is a collection of watch channels.
+type WatchSet map[<-chan struct{}]struct{}
+
+// NewWatchSet constructs a new watch set.
+func NewWatchSet() WatchSet {
+	return make(map[<-chan struct{}]struct{})
+}
+
+// Add appends a watchCh to the WatchSet if non-nil.
+func (w WatchSet) Add(watchCh <-chan struct{}) {
+	if w == nil {
+		return
+	}
+
+	if _, ok := w[watchCh]; !ok {
+		w[watchCh] = struct{}{}
+	}
+}
+
+// AddWithLimit appends a watchCh to the WatchSet if non-nil, and if the given
+// softLimit hasn't been exceeded. Otherwise, it will watch the given alternate
+// channel. It's expected that the altCh will be the same on many calls to this
+// function, so you will exceed the soft limit a little bit if you hit this, but
+// not by much.
+//
+// This is useful if you want to track individual items up to some limit, after
+// which you watch a higher-level channel (usually a channel from start start of
+// an iterator higher up in the radix tree) that will watch a superset of items.
+func (w WatchSet) AddWithLimit(softLimit int, watchCh <-chan struct{}, altCh <-chan struct{}) {
+	// This is safe for a nil WatchSet so we don't need to check that here.
+	if len(w) < softLimit {
+		w.Add(watchCh)
+	} else {
+		w.Add(altCh)
+	}
+}
+
+// Watch is used to wait for either the watch set to trigger or a timeout.
+// Returns true on timeout.
+func (w WatchSet) Watch(timeoutCh <-chan time.Time) bool {
+	if w == nil {
+		return false
+	}
+
+	// Create a context that gets cancelled when the timeout is triggered
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-timeoutCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return w.WatchCtx(ctx) == context.Canceled
+}
+
+// WatchCtx is used to wait for either the watch set to trigger or for the
+// context to be cancelled. Watch with a timeout channel can be mimicked by
+// creating a context with a deadline. WatchCtx should be preferred over Watch.
+func (w WatchSet) WatchCtx(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+
+	if n := len(w); n <= aFew {
+		idx := 0
+		chunk := make([]<-chan struct{}, aFew)
+		for watchCh := range w {
+			chunk[idx] = watchCh
+			idx++
+		}
+		return watchFew(ctx, chunk)
+	}
+
+	return w.watchMany(ctx)
+}
+
+// watchMany is used if there are many watchers.
+func (w WatchSet) watchMany(ctx context.Context) error {
+	// Set up a goroutine for each watcher.
+	triggerCh := make(chan struct{}, 1)
+	watcher := func(chunk []<-chan struct{}) {
+		if err := watchFew(ctx, chunk); err == nil {
+			select {
+			case triggerCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+
+	// Apportion the watch channels into chunks we can feed into the
+	// watchFew helper.
+	idx := 0
+	chunk := make([]<-chan struct{}, aFew)
+	for watchCh := range w {
+		subIdx := idx % aFew
+		chunk[subIdx] = watchCh
+		idx++
+
+		// Fire off this chunk and start a fresh one.
+		if idx%aFew == 0 {
+			go watcher(chunk)
+			chunk = make([]<-chan struct{}, aFew)
+		}
+	}
+
+	// Make sure to watch any residual channels in the last chunk.
+	if idx%aFew != 0 {
+		go watcher(chunk)
+	}
+
+	// Wait for a channel to trigger or timeout.
+	select {
+	case <-triggerCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/vendor/github.com/hashicorp/go-memdb/watch_few.go
+++ b/vendor/github.com/hashicorp/go-memdb/watch_few.go
@@ -1,0 +1,117 @@
+package memdb
+
+//go:generate sh -c "go run watch-gen/main.go >watch_few.go"
+
+import (
+	"context"
+)
+
+// aFew gives how many watchers this function is wired to support. You must
+// always pass a full slice of this length, but unused channels can be nil.
+const aFew = 32
+
+// watchFew is used if there are only a few watchers as a performance
+// optimization.
+func watchFew(ctx context.Context, ch []<-chan struct{}) error {
+	select {
+
+	case <-ch[0]:
+		return nil
+
+	case <-ch[1]:
+		return nil
+
+	case <-ch[2]:
+		return nil
+
+	case <-ch[3]:
+		return nil
+
+	case <-ch[4]:
+		return nil
+
+	case <-ch[5]:
+		return nil
+
+	case <-ch[6]:
+		return nil
+
+	case <-ch[7]:
+		return nil
+
+	case <-ch[8]:
+		return nil
+
+	case <-ch[9]:
+		return nil
+
+	case <-ch[10]:
+		return nil
+
+	case <-ch[11]:
+		return nil
+
+	case <-ch[12]:
+		return nil
+
+	case <-ch[13]:
+		return nil
+
+	case <-ch[14]:
+		return nil
+
+	case <-ch[15]:
+		return nil
+
+	case <-ch[16]:
+		return nil
+
+	case <-ch[17]:
+		return nil
+
+	case <-ch[18]:
+		return nil
+
+	case <-ch[19]:
+		return nil
+
+	case <-ch[20]:
+		return nil
+
+	case <-ch[21]:
+		return nil
+
+	case <-ch[22]:
+		return nil
+
+	case <-ch[23]:
+		return nil
+
+	case <-ch[24]:
+		return nil
+
+	case <-ch[25]:
+		return nil
+
+	case <-ch[26]:
+		return nil
+
+	case <-ch[27]:
+		return nil
+
+	case <-ch[28]:
+		return nil
+
+	case <-ch[29]:
+		return nil
+
+	case <-ch[30]:
+		return nil
+
+	case <-ch[31]:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/golang-lru
+
+go 1.12

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -73,6 +73,9 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
+		if ent.Value.(*entry) == nil {
+			return nil, false
+		}
 		return ent.Value.(*entry).value, true
 	}
 	return
@@ -140,6 +143,19 @@ func (c *LRU) Keys() []interface{} {
 // Len returns the number of items in the cache.
 func (c *LRU) Len() int {
 	return c.evictList.Len()
+}
+
+// Resize changes the cache size.
+func (c *LRU) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
 }
 
 // removeOldest removes the oldest item from the cache.

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -10,7 +10,7 @@ type LRUCache interface {
 	// updates the "recently used"-ness of the key. #value, isFound
 	Get(key interface{}) (value interface{}, ok bool)
 
-	// Check if a key exsists in cache without updating the recent-ness.
+	// Checks if a key exists in cache without updating the recent-ness.
 	Contains(key interface{}) (ok bool)
 
 	// Returns key's value without updating the "recently used"-ness of the key.
@@ -31,6 +31,9 @@ type LRUCache interface {
 	// Returns the number of items in the cache.
 	Len() int
 
-	// Clear all cache entries
+	// Clears all cache entries.
 	Purge()
+
+  // Resizes cache, returning number evicted
+  Resize(int) int
 }


### PR DESCRIPTION
### bump hashicorp/go-memdb v1.0.3

full diff: https://github.com/hashicorp/go-memdb/compare/cb9a474f84cc5e41b273b20c6927680b2a8776ad...v1.0.3

possibly relevant changes:

- hashicorp/go-memdb#21 Added a new MultiIndexer for map[string]string fields
- hashicorp/go-memdb#23 Adds support for fine-grained watches
- hashicorp/go-memdb#25 Delays mutation notifications until after the whole transaction is applied
  - fixes hashicorp/go-memdb#24 Notify channels close early during a commit
- hashicorp/go-memdb#26 Add a uint indexer
- hashicorp/go-memdb#31 Fix buffer size when encoding uint fields
- hashicorp/go-memdb#35 Add DeletePrefix method that allows faster deletes of objects in the id index
- hashicorp/go-memdb#37 Add WatchCtx function
- hashicorp/go-memdb#38 WatchCtx returns error
- hashicorp/go-memdb#39 Add a FilterIterator that wraps a ResultIterator
- hashicorp/go-memdb#42 use ErrNotFound for deleting missing item
- hashicorp/go-memdb#50 fix: dereference pointers for String Fields
- hashicorp/go-memdb#52 fix: allow nil string pointers
- hashicorp/go-memdb#59 Add Int indexing
- hashicorp/go-memdb#60 Add CompoundMultiIndexer
- hashicorp/go-memdb#61 Add LowerBound to allow for index range scans

### bump hashicorp/golang-lru v0.5.3

full diff: https://github.com/hashicorp/golang-lru/compare/v0.5.1...v0.5.3

- hashicorp/golang-lru#56 lru.Get(): avoid nil pointer dereference
- hashicorp/golang-lru#57 Adds LRU cache resize
- hashicorp/golang-lru#58 lru: don't kill the return values of Remove and RemoveOldest
