### PR TITLE
bump google/certificate-transparency-go v1.0.21

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@
 # In >=1.11, those errors were brought back but the string had changed again.
 # After updating GRPC, if integration test failures occur, verify that the
 # string matching there is correct.
-google.golang.org/grpc                              v1.23.0 
+google.golang.org/grpc                              v1.23.0
 github.com/gogo/protobuf                            b03c65ea87cdc3521ede29f62fe3ce239267c1bc # v1.3.2
 github.com/golang/protobuf                          84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
@@ -54,7 +54,7 @@ github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e83
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/dustin/go-humanize                       9f541cc9db5d55bce703bd99987c9d5cb8eea45e # v1.0.0
 github.com/fernet/fernet-go                         9eac43b88a5efb8651d24de9b68e87567e029736
-github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
+github.com/google/certificate-transparency-go       3629d6846518309d22c16fee15d1007262a459d2 # v1.0.21
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3

--- a/vendor/github.com/google/certificate-transparency-go/client/getentries.go
+++ b/vendor/github.com/google/certificate-transparency-go/client/getentries.go
@@ -66,7 +66,7 @@ func (c *LogClient) GetEntries(ctx context.Context, start, end int64) ([]ct.LogE
 	for i, entry := range resp.Entries {
 		index := start + int64(i)
 		logEntry, err := ct.LogEntryFromLeaf(index, &entry)
-		if _, ok := err.(x509.NonFatalErrors); !ok && err != nil {
+		if x509.IsFatal(err) {
 			return nil, err
 		}
 		entries[i] = *logEntry

--- a/vendor/github.com/google/certificate-transparency-go/serialization.go
+++ b/vendor/github.com/google/certificate-transparency-go/serialization.go
@@ -128,7 +128,7 @@ func MerkleTreeLeafFromRawChain(rawChain []ASN1Cert, etype LogEntryType, timesta
 	chain := make([]*x509.Certificate, count)
 	for i := range chain {
 		cert, err := x509.ParseCertificate(rawChain[i].Data)
-		if err != nil {
+		if x509.IsFatal(err) {
 			return nil, fmt.Errorf("failed to parse chain[%d] cert: %v", i, err)
 		}
 		chain[i] = cert
@@ -248,58 +248,94 @@ func IsPreIssuer(issuer *x509.Certificate) bool {
 	return false
 }
 
-// LogEntryFromLeaf converts a LeafEntry object (which has the raw leaf data after JSON parsing)
-// into a LogEntry object (which includes x509.Certificate objects, after TLS and ASN.1 parsing).
-// Note that this function may return a valid LogEntry object and a non-nil error value, when
-// the error indicates a non-fatal parsing error (of type x509.NonFatalErrors).
-func LogEntryFromLeaf(index int64, leafEntry *LeafEntry) (*LogEntry, error) {
-	var leaf MerkleTreeLeaf
-	if rest, err := tls.Unmarshal(leafEntry.LeafInput, &leaf); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal MerkleTreeLeaf for index %d: %v", index, err)
+// RawLogEntryFromLeaf converts a LeafEntry object (which has the raw leaf data
+// after JSON parsing) into a RawLogEntry object (i.e. a TLS-parsed structure).
+func RawLogEntryFromLeaf(index int64, entry *LeafEntry) (*RawLogEntry, error) {
+	ret := RawLogEntry{Index: index}
+	if rest, err := tls.Unmarshal(entry.LeafInput, &ret.Leaf); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal MerkleTreeLeaf: %v", err)
 	} else if len(rest) > 0 {
-		return nil, fmt.Errorf("trailing data (%d bytes) after MerkleTreeLeaf for index %d", len(rest), index)
+		return nil, fmt.Errorf("MerkleTreeLeaf: trailing data %d bytes", len(rest))
 	}
 
-	var err error
-	entry := LogEntry{Index: index, Leaf: leaf}
-	switch leaf.TimestampedEntry.EntryType {
+	switch eType := ret.Leaf.TimestampedEntry.EntryType; eType {
 	case X509LogEntryType:
 		var certChain CertificateChain
-		if rest, err := tls.Unmarshal(leafEntry.ExtraData, &certChain); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal ExtraData for index %d: %v", index, err)
+		if rest, err := tls.Unmarshal(entry.ExtraData, &certChain); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal CertificateChain: %v", err)
 		} else if len(rest) > 0 {
-			return nil, fmt.Errorf("trailing data (%d bytes) after CertificateChain for index %d", len(rest), index)
+			return nil, fmt.Errorf("CertificateChain: trailing data %d bytes", len(rest))
 		}
-		entry.Chain = certChain.Entries
-		entry.X509Cert, err = leaf.X509Certificate()
-		if _, ok := err.(x509.NonFatalErrors); !ok && err != nil {
-			return nil, fmt.Errorf("failed to parse certificate in MerkleTreeLeaf for index %d: %v", index, err)
-		}
+		ret.Cert = *ret.Leaf.TimestampedEntry.X509Entry
+		ret.Chain = certChain.Entries
 
 	case PrecertLogEntryType:
 		var precertChain PrecertChainEntry
-		if rest, err := tls.Unmarshal(leafEntry.ExtraData, &precertChain); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal PrecertChainEntry for index %d: %v", index, err)
+		if rest, err := tls.Unmarshal(entry.ExtraData, &precertChain); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal PrecertChainEntry: %v", err)
 		} else if len(rest) > 0 {
-			return nil, fmt.Errorf("trailing data (%d bytes) after PrecertChainEntry for index %d", len(rest), index)
+			return nil, fmt.Errorf("PrecertChainEntry: trailing data %d bytes", len(rest))
 		}
-		entry.Chain = precertChain.CertificateChain
+		ret.Cert = precertChain.PreCertificate
+		ret.Chain = precertChain.CertificateChain
+
+	default:
+		// TODO(pavelkalinnikov): Section 4.6 of RFC6962 implies that unknown types
+		// are not errors. We should revisit how we process this case.
+		return nil, fmt.Errorf("unknown entry type: %v", eType)
+	}
+
+	return &ret, nil
+}
+
+// ToLogEntry converts RawLogEntry to a LogEntry, which includes an x509-parsed
+// (pre-)certificate.
+//
+// Note that this function may return a valid LogEntry object and a non-nil
+// error value, when the error indicates a non-fatal parsing error.
+func (rle *RawLogEntry) ToLogEntry() (*LogEntry, error) {
+	var err error
+	entry := LogEntry{Index: rle.Index, Leaf: rle.Leaf, Chain: rle.Chain}
+
+	switch eType := rle.Leaf.TimestampedEntry.EntryType; eType {
+	case X509LogEntryType:
+		entry.X509Cert, err = rle.Leaf.X509Certificate()
+		if x509.IsFatal(err) {
+			return nil, fmt.Errorf("failed to parse certificate: %v", err)
+		}
+
+	case PrecertLogEntryType:
 		var tbsCert *x509.Certificate
-		tbsCert, err = leaf.Precertificate()
-		if _, ok := err.(x509.NonFatalErrors); !ok && err != nil {
-			return nil, fmt.Errorf("failed to parse precertificate in MerkleTreeLeaf for index %d: %v", index, err)
+		tbsCert, err = rle.Leaf.Precertificate()
+		if x509.IsFatal(err) {
+			return nil, fmt.Errorf("failed to parse precertificate: %v", err)
 		}
 		entry.Precert = &Precertificate{
-			Submitted:      precertChain.PreCertificate,
-			IssuerKeyHash:  leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash,
+			Submitted:      rle.Cert,
+			IssuerKeyHash:  rle.Leaf.TimestampedEntry.PrecertEntry.IssuerKeyHash,
 			TBSCertificate: tbsCert,
 		}
 
 	default:
-		return nil, fmt.Errorf("saw unknown entry type at index %d: %v", index, leaf.TimestampedEntry.EntryType)
+		return nil, fmt.Errorf("unknown entry type: %v", eType)
 	}
-	// err may hold a x509.NonFatalErrors object.
+
+	// err may be non-nil for a non-fatal error.
 	return &entry, err
+}
+
+// LogEntryFromLeaf converts a LeafEntry object (which has the raw leaf data
+// after JSON parsing) into a LogEntry object (which includes x509.Certificate
+// objects, after TLS and ASN.1 parsing).
+//
+// Note that this function may return a valid LogEntry object and a non-nil
+// error value, when the error indicates a non-fatal parsing error.
+func LogEntryFromLeaf(index int64, leaf *LeafEntry) (*LogEntry, error) {
+	rle, err := RawLogEntryFromLeaf(index, leaf)
+	if err != nil {
+		return nil, err
+	}
+	return rle.ToLogEntry()
 }
 
 // TimestampToTime converts a timestamp in the style of RFC 6962 (milliseconds

--- a/vendor/github.com/google/certificate-transparency-go/types.go
+++ b/vendor/github.com/google/certificate-transparency-go/types.go
@@ -199,6 +199,25 @@ func (d *DigitallySigned) UnmarshalJSON(b []byte) error {
 	return d.FromBase64String(content)
 }
 
+// RawLogEntry represents the (TLS-parsed) contents of an entry in a CT log.
+type RawLogEntry struct {
+	// Index is a position of the entry in the log.
+	Index int64
+	// Leaf is a parsed Merkle leaf hash input.
+	Leaf MerkleTreeLeaf
+	// Cert is:
+	// - A certificate if Leaf.TimestampedEntry.EntryType is X509LogEntryType.
+	// - A precertificate if Leaf.TimestampedEntry.EntryType is
+	//   PrecertLogEntryType, in the form of a DER-encoded Certificate as
+	//   originally added (which includes the poison extension and a signature
+	//   generated over the pre-cert by the pre-cert issuer).
+	// - Empty otherwise.
+	Cert ASN1Cert
+	// Chain is the issuing certificate chain starting with the issuer of Cert,
+	// or an empty slice if Cert is empty.
+	Chain []ASN1Cert
+}
+
 // LogEntry represents the (parsed) contents of an entry in a CT log.  This is described
 // in section 3.1, but note that this structure does *not* match the TLS structure
 // defined there (the TLS structure is never used directly in RFC6962).

--- a/vendor/github.com/google/certificate-transparency-go/x509/cert_pool.go
+++ b/vendor/github.com/google/certificate-transparency-go/x509/cert_pool.go
@@ -121,7 +121,7 @@ func (s *CertPool) AppendCertsFromPEM(pemCerts []byte) (ok bool) {
 		}
 
 		cert, err := ParseCertificate(block.Bytes)
-		if err != nil {
+		if IsFatal(err) {
 			continue
 		}
 

--- a/vendor/github.com/google/certificate-transparency-go/x509/curves.go
+++ b/vendor/github.com/google/certificate-transparency-go/x509/curves.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"crypto/elliptic"
+	"math/big"
+	"sync"
+)
+
+// This file holds ECC curves that are not supported by the main Go crypto/elliptic
+// library, but which have been observed in certificates in the wild.
+
+var initonce sync.Once
+var p192r1 *elliptic.CurveParams
+
+func initAllCurves() {
+	initSECP192R1()
+}
+
+func initSECP192R1() {
+	// See SEC-2, section 2.2.2
+	p192r1 = &elliptic.CurveParams{Name: "P-192"}
+	p192r1.P, _ = new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF", 16)
+	p192r1.N, _ = new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFF99DEF836146BC9B1B4D22831", 16)
+	p192r1.B, _ = new(big.Int).SetString("64210519E59C80E70FA7E9AB72243049FEB8DEECC146B9B1", 16)
+	p192r1.Gx, _ = new(big.Int).SetString("188DA80EB03090F67CBF20EB43A18800F4FF0AFD82FF1012", 16)
+	p192r1.Gy, _ = new(big.Int).SetString("07192B95FFC8DA78631011ED6B24CDD573F977A11E794811", 16)
+	p192r1.BitSize = 192
+}
+
+func secp192r1() elliptic.Curve {
+	initonce.Do(initAllCurves)
+	return p192r1
+}

--- a/vendor/github.com/google/certificate-transparency-go/x509/revoked.go
+++ b/vendor/github.com/google/certificate-transparency-go/x509/revoked.go
@@ -14,12 +14,15 @@ import (
 	"github.com/google/certificate-transparency-go/x509/pkix"
 )
 
+// OID values for CRL extensions (TBSCertList.Extensions), RFC 5280 s5.2.
 var (
-	// OID values for CRL extensions (TBSCertList.Extensions), RFC 5280 s5.2.
 	OIDExtensionCRLNumber                = asn1.ObjectIdentifier{2, 5, 29, 20}
 	OIDExtensionDeltaCRLIndicator        = asn1.ObjectIdentifier{2, 5, 29, 27}
 	OIDExtensionIssuingDistributionPoint = asn1.ObjectIdentifier{2, 5, 29, 28}
-	// OID values for CRL entry extensions (RevokedCertificate.Extensions), RFC 5280 s5.3
+)
+
+// OID values for CRL entry extensions (RevokedCertificate.Extensions), RFC 5280 s5.3
+var (
 	OIDExtensionCRLReasons        = asn1.ObjectIdentifier{2, 5, 29, 21}
 	OIDExtensionInvalidityDate    = asn1.ObjectIdentifier{2, 5, 29, 24}
 	OIDExtensionCertificateIssuer = asn1.ObjectIdentifier{2, 5, 29, 29}
@@ -238,7 +241,7 @@ func ParseCertificateListDER(derBytes []byte) (*CertificateList, error) {
 			}
 		case e.Id.Equal(OIDExtensionAuthorityInfoAccess):
 			// RFC 5280 s5.2.7
-			var aia []authorityInfoAccess
+			var aia []accessDescription
 			if rest, err := asn1.Unmarshal(e.Value, &aia); err != nil {
 				errs.AddID(ErrInvalidCertListAuthInfoAccess, err)
 			} else if len(rest) != 0 {

--- a/vendor/github.com/google/certificate-transparency-go/x509/rpki.go
+++ b/vendor/github.com/google/certificate-transparency-go/x509/rpki.go
@@ -1,0 +1,242 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package x509
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/google/certificate-transparency-go/asn1"
+)
+
+// IPAddressPrefix describes an IP address prefix as an ASN.1 bit string,
+// where the BitLength field holds the prefix length.
+type IPAddressPrefix asn1.BitString
+
+// IPAddressRange describes an (inclusive) IP address range.
+type IPAddressRange struct {
+	Min IPAddressPrefix
+	Max IPAddressPrefix
+}
+
+// Most relevant values for AFI from:
+// http://www.iana.org/assignments/address-family-numbers.
+const (
+	IPv4AddressFamilyIndicator = uint16(1)
+	IPv6AddressFamilyIndicator = uint16(2)
+)
+
+// IPAddressFamilyBlocks describes a set of ranges of IP addresses.
+type IPAddressFamilyBlocks struct {
+	// AFI holds an address family indicator from
+	// http://www.iana.org/assignments/address-family-numbers.
+	AFI uint16
+	// SAFI holds a subsequent address family indicator from
+	// http://www.iana.org/assignments/safi-namespace.
+	SAFI byte
+	// InheritFromIssuer indicates that the set of addresses should
+	// be taken from the issuer's certificate.
+	InheritFromIssuer bool
+	// AddressPrefixes holds prefixes if InheritFromIssuer is false.
+	AddressPrefixes []IPAddressPrefix
+	// AddressRanges holds ranges if InheritFromIssuer is false.
+	AddressRanges []IPAddressRange
+}
+
+// Internal types for asn1 unmarshalling.
+type ipAddressFamily struct {
+	AddressFamily []byte // 2-byte AFI plus optional 1 byte SAFI
+	Choice        asn1.RawValue
+}
+
+// Internally, use raw asn1.BitString rather than the IPAddressPrefix
+// type alias (so that asn1.Unmarshal() decodes properly).
+type ipAddressRange struct {
+	Min asn1.BitString
+	Max asn1.BitString
+}
+
+func parseRPKIAddrBlocks(data []byte, nfe *NonFatalErrors) []*IPAddressFamilyBlocks {
+	// RFC 3779 2.2.3
+	//   IPAddrBlocks        ::= SEQUENCE OF IPAddressFamily
+	//
+	//   IPAddressFamily     ::= SEQUENCE {    -- AFI & optional SAFI --
+	//      addressFamily        OCTET STRING (SIZE (2..3)),
+	//      ipAddressChoice      IPAddressChoice }
+	//
+	//   IPAddressChoice     ::= CHOICE {
+	//      inherit              NULL, -- inherit from issuer --
+	//      addressesOrRanges    SEQUENCE OF IPAddressOrRange }
+	//
+	//   IPAddressOrRange    ::= CHOICE {
+	//      addressPrefix        IPAddress,
+	//      addressRange         IPAddressRange }
+	//
+	//   IPAddressRange      ::= SEQUENCE {
+	//      min                  IPAddress,
+	//      max                  IPAddress }
+	//
+	//   IPAddress           ::= BIT STRING
+
+	var addrBlocks []ipAddressFamily
+	if rest, err := asn1.Unmarshal(data, &addrBlocks); err != nil {
+		nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ipAddrBlocks extension: %v", err))
+		return nil
+	} else if len(rest) != 0 {
+		nfe.AddError(errors.New("trailing data after ipAddrBlocks extension"))
+		return nil
+	}
+
+	var results []*IPAddressFamilyBlocks
+	for i, block := range addrBlocks {
+		var fam IPAddressFamilyBlocks
+		if l := len(block.AddressFamily); l < 2 || l > 3 {
+			nfe.AddError(fmt.Errorf("invalid address family length (%d) for ipAddrBlock.addressFamily", l))
+			continue
+		}
+		fam.AFI = binary.BigEndian.Uint16(block.AddressFamily[0:2])
+		if len(block.AddressFamily) > 2 {
+			fam.SAFI = block.AddressFamily[2]
+		}
+		// IPAddressChoice is an ASN.1 CHOICE where the chosen alternative is indicated by (implicit)
+		// tagging of the alternatives -- here, either NULL or SEQUENCE OF.
+		if bytes.Equal(block.Choice.FullBytes, asn1.NullBytes) {
+			fam.InheritFromIssuer = true
+			results = append(results, &fam)
+			continue
+		}
+
+		var addrRanges []asn1.RawValue
+		if _, err := asn1.Unmarshal(block.Choice.FullBytes, &addrRanges); err != nil {
+			nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ipAddrBlocks[%d].ipAddressChoice.addressesOrRanges: %v", i, err))
+			continue
+		}
+		for j, ar := range addrRanges {
+			// Each IPAddressOrRange is a CHOICE where the alternatives have distinct (implicit)
+			// tags -- here, either BIT STRING or SEQUENCE.
+			switch ar.Tag {
+			case asn1.TagBitString:
+				// BIT STRING for single prefix IPAddress
+				var val asn1.BitString
+				if _, err := asn1.Unmarshal(ar.FullBytes, &val); err != nil {
+					nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ipAddrBlocks[%d].ipAddressChoice.addressesOrRanges[%d].addressPrefix: %v", i, j, err))
+					continue
+				}
+				fam.AddressPrefixes = append(fam.AddressPrefixes, IPAddressPrefix(val))
+
+			case asn1.TagSequence:
+				var val ipAddressRange
+				if _, err := asn1.Unmarshal(ar.FullBytes, &val); err != nil {
+					nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ipAddrBlocks[%d].ipAddressChoice.addressesOrRanges[%d].addressRange: %v", i, j, err))
+					continue
+				}
+				fam.AddressRanges = append(fam.AddressRanges, IPAddressRange{Min: IPAddressPrefix(val.Min), Max: IPAddressPrefix(val.Max)})
+
+			default:
+				nfe.AddError(fmt.Errorf("unexpected ASN.1 type in ipAddrBlocks[%d].ipAddressChoice.addressesOrRanges[%d]: %+v", i, j, ar))
+			}
+		}
+		results = append(results, &fam)
+	}
+	return results
+}
+
+// ASIDRange describes an inclusive range of AS Identifiers (AS numbers or routing
+// domain identifiers).
+type ASIDRange struct {
+	Min int
+	Max int
+}
+
+// ASIdentifiers describes a collection of AS Identifiers (AS numbers or routing
+// domain identifiers).
+type ASIdentifiers struct {
+	// InheritFromIssuer indicates that the set of AS identifiers should
+	// be taken from the issuer's certificate.
+	InheritFromIssuer bool
+	// ASIDs holds AS identifiers if InheritFromIssuer is false.
+	ASIDs []int
+	// ASIDs holds AS identifier ranges (inclusive) if InheritFromIssuer is false.
+	ASIDRanges []ASIDRange
+}
+
+type asIdentifiers struct {
+	ASNum asn1.RawValue `asn1:"optional,tag:0"`
+	RDI   asn1.RawValue `asn1:"optional,tag:1"`
+}
+
+func parseASIDChoice(val asn1.RawValue, nfe *NonFatalErrors) *ASIdentifiers {
+	// RFC 3779 2.3.2
+	//   ASIdentifierChoice  ::= CHOICE {
+	//      inherit              NULL, -- inherit from issuer --
+	//      asIdsOrRanges        SEQUENCE OF ASIdOrRange }
+	//   ASIdOrRange         ::= CHOICE {
+	//       id                  ASId,
+	//       range               ASRange }
+	//   ASRange             ::= SEQUENCE {
+	//       min                 ASId,
+	//       max                 ASId }
+	//   ASId                ::= INTEGER
+	if len(val.FullBytes) == 0 { // OPTIONAL
+		return nil
+	}
+	// ASIdentifierChoice is an ASN.1 CHOICE where the chosen alternative is indicated by (implicit)
+	// tagging of the alternatives -- here, either NULL or SEQUENCE OF.
+	if bytes.Equal(val.Bytes, asn1.NullBytes) {
+		return &ASIdentifiers{InheritFromIssuer: true}
+	}
+	var ids []asn1.RawValue
+	if rest, err := asn1.Unmarshal(val.Bytes, &ids); err != nil {
+		nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ASIdentifiers.asIdsOrRanges: %v", err))
+		return nil
+	} else if len(rest) != 0 {
+		nfe.AddError(errors.New("trailing data after ASIdentifiers.asIdsOrRanges"))
+		return nil
+	}
+	var asID ASIdentifiers
+	for i, id := range ids {
+		// Each ASIdOrRange is a CHOICE where the alternatives have distinct (implicit)
+		// tags -- here, either INTEGER or SEQUENCE.
+		switch id.Tag {
+		case asn1.TagInteger:
+			var val int
+			if _, err := asn1.Unmarshal(id.FullBytes, &val); err != nil {
+				nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ASIdentifiers.asIdsOrRanges[%d].id: %v", i, err))
+				continue
+			}
+			asID.ASIDs = append(asID.ASIDs, val)
+
+		case asn1.TagSequence:
+			var val ASIDRange
+			if _, err := asn1.Unmarshal(id.FullBytes, &val); err != nil {
+				nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ASIdentifiers.asIdsOrRanges[%d].range: %v", i, err))
+				continue
+			}
+			asID.ASIDRanges = append(asID.ASIDRanges, val)
+
+		default:
+			nfe.AddError(fmt.Errorf("unexpected value in ASIdentifiers.asIdsOrRanges[%d]: %+v", i, id))
+		}
+	}
+	return &asID
+}
+
+func parseRPKIASIdentifiers(data []byte, nfe *NonFatalErrors) (*ASIdentifiers, *ASIdentifiers) {
+	// RFC 3779 2.3.2
+	//   ASIdentifiers       ::= SEQUENCE {
+	//       asnum               [0] EXPLICIT ASIdentifierChoice OPTIONAL,
+	//       rdi                 [1] EXPLICIT ASIdentifierChoice OPTIONAL}
+	var asIDs asIdentifiers
+	if rest, err := asn1.Unmarshal(data, &asIDs); err != nil {
+		nfe.AddError(fmt.Errorf("failed to asn1.Unmarshal ASIdentifiers extension: %v", err))
+		return nil, nil
+	} else if len(rest) != 0 {
+		nfe.AddError(errors.New("trailing data after ASIdentifiers extension"))
+		return nil, nil
+	}
+	return parseASIDChoice(asIDs.ASNum, nfe), parseASIDChoice(asIDs.RDI, nfe)
+}

--- a/vendor/github.com/google/certificate-transparency-go/x509/sec1.go
+++ b/vendor/github.com/google/certificate-transparency-go/x509/sec1.go
@@ -72,11 +72,12 @@ func parseECPrivateKey(namedCurveOID *asn1.ObjectIdentifier, der []byte) (key *e
 		return nil, fmt.Errorf("x509: unknown EC private key version %d", privKey.Version)
 	}
 
+	var nfe NonFatalErrors
 	var curve elliptic.Curve
 	if namedCurveOID != nil {
-		curve = namedCurveFromOID(*namedCurveOID)
+		curve = namedCurveFromOID(*namedCurveOID, &nfe)
 	} else {
-		curve = namedCurveFromOID(privKey.NamedCurveOID)
+		curve = namedCurveFromOID(privKey.NamedCurveOID, &nfe)
 	}
 	if curve == nil {
 		return nil, errors.New("x509: unknown elliptic curve")


### PR DESCRIPTION
full diff: https://github.com/google/certificate-transparency-go/compare/v1.0.20...v1.0.21

- CTFE no longer prints certificate chains as long byte strings in messages when
  handler errors occur. This was obscuring the reason for the failure and wasn't
  particularly useful.
- CTFE now has a global log URL path prefix flag and a configuration proto for a
  log specific path. The latter should help for various migration strategies if
  existing C++ server logs are going to be converted to run on the new code.
- More progress has been made on log mirroring. We believe that it's now at the
  point where testing can begin.
- The certcheck and ct_hammer utilities have received more enhancements.
- x509 and x509util now support Subject Information Access and additional exten-
  sions for RPKI / RFC
- scanner / fixchain and some other command line utilities now have better
  handling of non-fatal errors.
