### PR TITLE
[bump_20.10 backport ]Fix panic in agent

### DIFF
--- a/agent/exec/errors.go
+++ b/agent/exec/errors.go
@@ -65,17 +65,14 @@ func (t temporary) Temporary() bool { return true }
 // IsTemporary returns true if the error or a recursive cause returns true for
 // temporary.
 func IsTemporary(err error) bool {
-	for err != nil {
-		if tmp, ok := err.(Temporary); ok && tmp.Temporary() {
-			return true
-		}
+	if tmp, ok := err.(Temporary); ok && tmp.Temporary() {
+		return true
+	}
 
-		cause := errors.Cause(err)
-		if cause == err {
-			break
-		}
+	cause := errors.Cause(err)
 
-		err = cause
+	if tmp, ok := cause.(Temporary); ok && tmp.Temporary() {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
backport of https://github.com/docker/swarmkit/pull/3024 for 20.10 (already back ported to 19.03 through https://github.com/docker/swarmkit/pull/3031)


Previously, there was an issue where the agent could panic while
attempting to determine if an error was temporary.

Before the change, in `agent/exec/errors.go`, the function `IsTemporary`
attempted to drill down to a root cause by iterating through the causes
of an error by calling `errors.Cause`. If an error has no cause, then
`errors.Cause` returns that same error.

The issue is that somewhere in the depths of some code, it was posssible
for the error to have an underlying type that was non-comparable; for
example, maps and slices are uncomparable types. This would cause a
panic, as the uncomparable type cannot be compared even to itself.

However, one can see that `errors.Cause` has its own loop, and drills
down to the root cause in its own way. There is no need for us to
iterate here.

Instead, we can just take a look at the error itself, and then take a
look at its cause once. If neither is temporary, the error is not
temporary, and we have nothing to worry about.

Signed-off-by: Drew Erny <derny@mirantis.com>
(cherry picked from commit 39a4233ee6f3f87a83da0e64386fbeb09cdd88b7)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
