### PR TITLE
agent/exec: rewrite IsTemporary() to use errors.As()

### DIFF
--- a/agent/exec/errors.go
+++ b/agent/exec/errors.go
@@ -70,15 +70,9 @@ func (t temporary) Temporary() bool { return true }
 // IsTemporary returns true if the error or a recursive cause returns true for
 // temporary.
 func IsTemporary(err error) bool {
-	if tmp, ok := err.(Temporary); ok && tmp.Temporary() {
-		return true
+	var tmp Temporary
+	if errors.As(err, &tmp) {
+		return tmp.Temporary()
 	}
-
-	cause := errors.Cause(err)
-
-	if tmp, ok := cause.(Temporary); ok && tmp.Temporary() {
-		return true
-	}
-
 	return false
 }

--- a/agent/exec/errors_test.go
+++ b/agent/exec/errors_test.go
@@ -1,0 +1,27 @@
+package exec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestIsTemporary(t *testing.T) {
+	err := fmt.Errorf("err")
+	err1 := MakeTemporary(fmt.Errorf("err1: %w", err))
+	err2 := fmt.Errorf("err2: %w", err1)
+	err3 := errors.Wrap(err2, "err3")
+	err4 := fmt.Errorf("err4: %w", err3)
+	err5 := errors.Wrap(err4, "err5")
+
+	if IsTemporary(nil) {
+		t.Error("expected error to not be a temporary error")
+	}
+	if IsTemporary(err) {
+		t.Error("expected error to not be a temporary error")
+	}
+	if !IsTemporary(err5) {
+		t.Error("expected error to be a temporary error")
+	}
+}


### PR DESCRIPTION
follow-up to https://github.com/docker/swarmkit/pull/3024

Implements the suggestion I made in https://github.com/docker/swarmkit/pull/3032#discussion_r737316923

This makes sure we detect temporary errors both with pkg/errors.Wrap()
and with native Go error wrapping.
