### PR TITLE
ci: fix installation of golangci-lint

### DIFF
--- a/direct.mk
+++ b/direct.mk
@@ -37,9 +37,8 @@ version/version.go:
 .PHONY: setup
 setup: ## install dependencies
 	@echo "🐳 $@"
-	# TODO(stevvooe): Install these from the vendor directory
 	# install golangci-lint version 1.17.1 to ./bin/golangci-lint
-	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
+	@curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v1.17.1/install.sh | sh -s v1.17.1
 	@(cd tools ; GO111MODULE=on go install github.com/containerd/protobuild)
 
 .PHONY: generate


### PR DESCRIPTION
The `install.goreleaser.com` domain no longer exists, so using the GitHub URL, as described in the docs; https://golangci-lint.run/usage/install/#other-ci
