### PR TITLE
Fixes https://github.com/moby/moby/issues/44378

### DIFF
--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -174,16 +174,21 @@ loop:
 				removeTasks[t.ID] = t
 				continue
 			}
+
+			available.MemoryBytes -= t.Spec.Resources.Reservations.MemoryBytes
+			available.NanoCPUs -= t.Spec.Resources.Reservations.NanoCPUs
+		}
+
+		// Ensure that the task assigned to the node
+		// still satisfies the available generic resources
+		if t.AssignedGenericResources != nil {
 			for _, ta := range t.AssignedGenericResources {
 				// Type change or no longer available
-				if genericresource.HasResource(ta, available.Generic) {
+				if !genericresource.HasResource(ta, available.Generic) {
 					removeTasks[t.ID] = t
 					break loop
 				}
 			}
-
-			available.MemoryBytes -= t.Spec.Resources.Reservations.MemoryBytes
-			available.NanoCPUs -= t.Spec.Resources.Reservations.NanoCPUs
 
 			genericresource.ClaimResources(&available.Generic,
 				&fakeStore, t.AssignedGenericResources)


### PR DESCRIPTION
AssignedGenericResources in constraint_enforcer.go were falsely checked inside a case that enforced Reservations to be set Furthermore, the if statement had a missing !

Signed-off-by: Martin Braun <braun@neuroforge.de>


**- What I did**

Fixed a inverted logic bug in constraint_enforcer.go that should fix https://github.com/moby/moby/issues/44378

**- How I did it**

I added a test for constraint_enforcer_test.go that checks for proper enforcement of generic resources being present. While doing so, I noticed that the checks for AssignedGenericResources were done inside a check for the resources. This seemed wrong, so I moved the logic outside of the if statement.

**- How to test it**

**- Description for the changelog**

Fixed a inverted logic bug in constraint_enforcer.go that should fix https://github.com/moby/moby/issues/44378
