### PR TITLE
ca: remove uses of deprecated go-digest.Digest.Hex()

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -754,7 +754,7 @@ func GetRemoteCA(ctx context.Context, d digest.Digest, connBroker *connectionbro
 		io.Copy(verifier, bytes.NewReader(response.Certificate))
 
 		if !verifier.Verified() {
-			return RootCA{}, errors.Errorf("remote CA does not match fingerprint. Expected: %s", d.Hex())
+			return RootCA{}, errors.Errorf("remote CA does not match fingerprint. Expected: %s", d.Encoded())
 		}
 	}
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -367,16 +367,16 @@ func GenerateJoinToken(rootCA *RootCA, fips bool) string {
 		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
 
-	var nn, digest big.Int
+	var nn, dgst big.Int
 	nn.SetBytes(secretBytes[:])
-	digest.SetString(rootCA.Digest.Hex(), 16)
+	dgst.SetString(rootCA.Digest.Encoded(), 16)
 
 	fmtString := "SWMTKN-1-%0[1]*s-%0[3]*s"
 	if fips {
 		fmtString = "SWMTKN-2-1-%0[1]*s-%0[3]*s"
 	}
 	return fmt.Sprintf(fmtString, base36DigestLen,
-		digest.Text(joinTokenBase), maxGeneratedSecretLength, nn.Text(joinTokenBase))
+		dgst.Text(joinTokenBase), maxGeneratedSecretLength, nn.Text(joinTokenBase))
 }
 
 // DownloadRootCA tries to retrieve a remote root CA and matches the digest against the provided token.


### PR DESCRIPTION
- relates to https://github.com/opencontainers/go-digest/pull/83

This function was in https://github.com/opencontainers/go-digest/commit/55f675811a1b915549933c64571fd86b2676ba76 (https://github.com/opencontainers/go-digest/pull/33), but the format of the GoDoc comments didn't follow the correct format, which caused it not being picked up by tools as "deprecated".

This patch updates uses in the codebase to use the alternatives.

