### PR TITLE
Makefile: coverage: don't run tests twice

### DIFF
--- a/direct.mk
+++ b/direct.mk
@@ -119,7 +119,6 @@ coverage: ## generate coverprofiles from the unit tests
 	@echo "🐳 $@"
 	@( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}); do \
 		go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" $$pkg)/coverage.txt" -covermode=atomic $$pkg || exit; \
-		go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" $$pkg)/coverage.txt" -covermode=atomic $$pkg || exit; \
 	done )
 
 .PHONY: coverage-integration


### PR DESCRIPTION
- relates to https://github.com/moby/swarmkit/pull/215
- relates to https://github.com/moby/swarmkit/pull/2751

### Makefile: coverage: don't run tests twice

Initially the tests were run twice, once with "-i" to "pre build" the tests;
8ebe4356ea2f659758a130ddbed623b7f7010868

Commit cb50952a3a15a58bbbb76003994a694d7a658872 removed the "-i" options,
as it's no longer needed since go1.10, however it did not remove the
(now duplicate) line, so tests were running twice.

Before this, every test was run twice:

<img width="898" alt="Screenshot 2022-11-19 at 17 19 45" src="https://user-images.githubusercontent.com/1804568/202860935-54b8159d-c78b-4c73-8c4f-0f0073e710ea.png">

After this, tests are only run once (cutting the time for the unit tests in ~half 😂)

<img width="888" alt="Screenshot 2022-11-19 at 17 20 04" src="https://user-images.githubusercontent.com/1804568/202860936-605d9a74-4846-4eaa-ac3e-5645af767e32.png">

