### PR TITLE
Makefile: go-mod-vendor: fix copying of gogo/protobuf

### DIFF
--- a/direct.mk
+++ b/direct.mk
@@ -143,6 +143,6 @@ go-mod-vendor:
 	@go mod vendor
 	@# ensure that key protobuf spec files are in vendor dir
 	@module=github.com/gogo/protobuf ; \
-		prefix=$$(go env GOPATH)/pkg/mod/$${module} ; \
+		prefix=$$(go env GOMODCACHE)/$${module} ; \
 		version=$$(go list -m -f '{{.Version}}' $${module}) ; \
 		cp -a $${prefix}@$${version}/protobuf vendor/$${module}/ && chmod -R u+w vendor/$${module}


### PR DESCRIPTION
- relates to https://github.com/moby/swarmkit/pull/3070

Possibly it's using a non-standard location;

    cp: cannot stat '/home/circleci/.go_workspace:/usr/local/go_workspace/pkg/mod/github.com/gogo/protobuf@v1.3.2/protobuf': No such file or directory
    make: *** [direct.mk:146: go-mod-vendor] Error 1

So, using GOMODCACHE path instead of trying to construct our own.
