### PR TITLE
manager/state/raft/storage: TestReadRepairWAL: fix for etcd v3.5.5

### DIFF
--- a/manager/state/raft/storage/walwrap.go
+++ b/manager/state/raft/storage/walwrap.go
@@ -174,7 +174,11 @@ func ReadRepairWAL(
 				return nil, WALData{}, errors.Wrap(err, "failed to decrypt WAL")
 			}
 			// we can only repair ErrUnexpectedEOF and we never repair twice.
-			if repaired || err != io.ErrUnexpectedEOF {
+			if repaired || !errors.Is(err, io.ErrUnexpectedEOF) {
+				// TODO(thaJeztah): should ReadRepairWAL be updated to handle cases where
+				// some (last) of the files cannot be recovered? ("best effort" recovery?)
+				// Or should an informative error be produced to help the user (which could
+				// mean: remove the last file?). See TestReadRepairWAL for more details.
 				return nil, WALData{}, errors.Wrap(err, "irreparable WAL error")
 			}
 			if !wal.Repair(nil, walDir) {


### PR DESCRIPTION
- relates to https://github.com/moby/swarmkit/pull/3085

etcd server v3.5.5 includes a fix to prevent the reader from trying to read more data than available in the file, introduced in https://github.com/etcd-io/etcd/commit/621cd7b9e5aa2ccf634b555e4ebe0037b8975066

> restrict the max size of each WAL entry to the remaining size of the file
>
> Currently the max size of each WAL entry is hard coded as 10MB. If users
> set a value > 10MB for the flag --max-request-bytes, then etcd may run
> into a situation that it successfully processes a big request, but fails
> to decode it when replaying the WAL file on startup.
>
> On the other hand, we can't just remove the limitation, because if a
> WAL entry is somehow corrupted, and its recByte is a huge value, then
> etcd may run out of memory. So the solution is to restrict the max size
> of each WAL entry as a dynamic value, which is the remaining size of
> the WAL file.

This patch updates the test to have sufficient data available in the corrupted file to perform recovery.
