### PR TITLE
manager/state/raft/storage: MigrateSnapshot fix etcd v3.5.6 compatiblity

### DIFF
--- a/manager/state/raft/storage/snapwrap.go
+++ b/manager/state/raft/storage/snapwrap.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/moby/swarmkit/v2/manager/encryption"
 	"github.com/pkg/errors"
-	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
 )
@@ -118,12 +117,10 @@ func MigrateSnapshot(oldDir, newDir string, oldFactory, newFactory SnapFactory) 
 	}
 
 	tmpdirpath := filepath.Clean(newDir) + ".tmp"
-	if fileutil.Exist(tmpdirpath) {
-		if err := os.RemoveAll(tmpdirpath); err != nil {
-			return errors.Wrap(err, "could not remove temporary snapshot directory")
-		}
+	if err := os.RemoveAll(tmpdirpath); err != nil {
+		return errors.Wrap(err, "could not remove temporary snapshot directory")
 	}
-	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
+	if err := os.MkdirAll(tmpdirpath, 0o700); err != nil {
 		return errors.Wrap(err, "could not create temporary snapshot directory")
 	}
 	tmpSnapshotter := newFactory.New(tmpdirpath)


### PR DESCRIPTION
Commit https://github.com/etcd-io/etcd/commit/3644c9d67ba0316c1c8f7c7d96316bf739234381 (https://github.com/etcd-io/etcd/pull/13401) changed the signature of fileutil.CreateDirAll to now require a go.uber.org/zap.Logger to be passed.

Unfortunately that's a type (not an interface), which results in go.uber.org/zap.Logger to be a direct dependency.

Looking at what fileutil.CreateDirAll does;

- It checks if each directory exists, and has the expected permissions (0700).
- It checks if each directory is empty.

Given that we already delete the directory (and terminate if that fails) before we create the new location, that functionality is redundant, so we can just as well use `os.MkdirAll()` to achieve the same.

