### PR TITLE
ci: init gha workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3


### PR DESCRIPTION
Just checking out the repo to warmup GitHub Actions on this repo so we can open follow-ups to switch to GHA.

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>