### PR TITLE
ci: validation and unit/integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,3 @@ jobs:
         command: |
             # TMPFS has already been set up previously in the unit test step
             TMPDIR=/tmpfs make coverage-integration
-
-    - run:
-        name: Push coverage info to codecov.io
-        command: bash <(curl -fsSL https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,60 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
+env:
+  DOCKER_SWARMKIT_USE_CONTAINER: 1
+  IMAGE_NAME: moby/swarmkit
+
 jobs:
-  build:
+  build-dev:
     runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build dev image
+        uses: docker/bake-action@v2
+        with:
+          targets: dev
+          set: |
+            *.cache-from=type=gha,scope=dev${{ matrix.mode }}
+            *.cache-to=type=gha,scope=dev${{ matrix.mode }},mode=max
+            *.output=type=cacheonly
+
+  test:
+    runs-on: ubuntu-22.04
+    needs:
+      - build-dev
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - coverage
+          - coverage-integration
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build dev image
+        uses: docker/bake-action@v2
+        with:
+          targets: dev
+          set: |
+            *.cache-from=type=gha,scope=dev
+      -
+        name: Test
+        run: |
+          make IMAGE_NAME=$IMAGE_NAME ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,9 @@ jobs:
         name: Test
         run: |
           make IMAGE_NAME=$IMAGE_NAME ${{ matrix.target }}
+      -
+        name: Send to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: RUNNER_OS
+          flags: ${{ matrix.target }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+name: validate
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+env:
+  DOCKER_SWARMKIT_USE_CONTAINER: 1
+
+jobs:
+  validate:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - lint
+          - generate-validate
+          - vendor-validate
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Run
+        run: |
+          make ${{ matrix.target }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,85 @@
-# NOTE(dperny): for some reason, alpine was giving me trouble
+# syntax=docker/dockerfile:1
+
 ARG GO_VERSION=1.18.9
-ARG DEBIAN_FRONTEND=noninteractive
-ARG BASE_DEBIAN_DISTRO="bullseye"
-ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
-
-FROM ${GOLANG_IMAGE}
-
-RUN apt-get update && apt-get install -y make git unzip
-
-# should stay consistent with the version in .circleci/config.yml
 ARG PROTOC_VERSION=3.11.4
-# download and install protoc binary and .proto files
-RUN curl --silent --show-error --location --output protoc.zip \
-  https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \
-  && unzip -d /usr/local protoc.zip include/\* bin/\* \
-  && rm -f protoc.zip
+ARG DEBIAN_FRONTEND=noninteractive
 
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bullseye AS gobase
+ARG DEBIAN_FRONTEND
+RUN apt-get update && apt-get install -y --no-install-recommends git make rsync
+WORKDIR /go/src/github.com/docker/swarmkit
+
+FROM gobase AS packages
+RUN --mount=target=. \
+  mkdir -p /tmp/packages && \
+  echo $(go list ./...) | tee /tmp/packages/packages; \
+  echo $(go list ./integration) | tee /tmp/packages/integration-packages;
+
+FROM gobase AS protoc-gen-gogoswarm
+RUN --mount=type=bind,target=.,rw \
+    --mount=type=cache,target=/root/.cache \
+    make bin/protoc-gen-gogoswarm && mv bin/protoc-gen-gogoswarm /usr/local/bin/
+
+FROM gobase AS protobuild
+RUN --mount=type=bind,source=tools,target=. \
+    --mount=target=/go/pkg/mod,type=cache \
+    --mount=type=cache,target=/root/.cache \
+    go install -mod=mod github.com/containerd/protobuild
+
+FROM gobase AS generate-base
+ARG DEBIAN_FRONTEND
+RUN apt-get --no-install-recommends install -y unzip
+ARG PROTOC_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+RUN <<EOT
+  set -e
+  arch=$(echo $TARGETARCH | sed -e s/amd64/x86_64/ -e s/arm64/aarch_64/)
+  wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip
+  unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local
+EOT
+
+FROM generate-base AS generate-build
+RUN --mount=type=bind,target=.,rw \
+    --mount=from=packages,source=/tmp/packages,target=/tmp/packages \
+    --mount=from=protobuild,source=/go/bin/protobuild,target=/usr/bin/protobuild \
+    --mount=from=protoc-gen-gogoswarm,source=/usr/local/bin/protoc-gen-gogoswarm,target=/usr/bin/protoc-gen-gogoswarm <<EOT
+  set -ex
+  protobuild $(cat /tmp/packages/packages)
+  go generate -mod=vendor -x $(cat /tmp/packages/packages)
+  mkdir /out
+  git ls-files -m --others -- ':!vendor' '**/*.pb.go' | tar -cf - --files-from - | tar -C /out -xf -
+EOT
+
+FROM scratch AS generate-update
+COPY --from=generate-build /out /
+
+FROM gobase AS generate-validate
+RUN --mount=type=bind,target=.,rw \
+    --mount=type=bind,from=generate-build,source=/out,target=/generated <<EOT
+  set -e
+  git add -A
+  if [ "$(ls -A /generated)" ]; then
+    cp -rf /generated/* .
+  fi
+  diff=$(git status --porcelain -- ':!vendor' '**/*.pb.go')
+  if [ -n "$diff" ]; then
+    echo >&2 'ERROR: The result of "go generate" differs. Please update with "make generate"'
+    echo "$diff"
+    exit 1
+  fi
+EOT
+
+# use generate-base to have protoc available
+FROM generate-base
 ENV GO111MODULE=on
-WORKDIR /go/src/github.com/docker/swarmkit/
-
 # install the dependencies from `make setup`
 # we only copy `direct.mk` to avoid busting the cache too easily
 COPY direct.mk .
 COPY tools .
 RUN make --file=direct.mk setup
-
 # now we can copy the rest
 COPY . .
-
 # default to just `make`. If you want to change the default command, change the
 # default make command, not this command.
 CMD ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,10 @@ RUN --mount=type=bind,target=. \
     --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
     golangci-lint run ./...
 
+FROM gobase AS fmt-proto
+RUN --mount=type=bind,target=. \
+    make fmt-proto
+
 # use generate-base to have protoc available
 FROM generate-base
 ENV GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # [SwarmKit](https://github.com/moby/swarmkit)
 
-[![GoDoc](https://godoc.org/github.com/moby/swarmkit?status.svg)](https://godoc.org/github.com/moby/swarmkit)
-[![Circle CI](https://circleci.com/gh/moby/swarmkit.svg?style=shield&circle-token=a7bf494e28963703a59de71cf19b73ad546058a7)](https://circleci.com/gh/moby/swarmkit)
-[![codecov.io](https://codecov.io/github/moby/swarmkit/coverage.svg?branch=master&token=LqD1dzTjsN)](https://codecov.io/github/moby/swarmkit?branch=master)
-[![Badge Badge](http://doyouevenbadge.com/github.com/moby/swarmkit)](http://doyouevenbadge.com/report/github.com/moby/swarmkit)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/moby/swarmkit)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/moby/swarmkit/ci.yml?branch=master&label=ci&logo=github&style=flat-square)](https://github.com/moby/swarmkit/actions?query=workflow%3Aci)
+[![Go Report Card](https://goreportcard.com/badge/github.com/moby/swarmkit)](https://goreportcard.com/report/github.com/moby/swarmkit)
+[![codecov](https://img.shields.io/codecov/c/github/moby/swarmkit?logo=codecov&style=flat-square)](https://codecov.io/gh/moby/swarmkit)
 
 *SwarmKit* is a toolkit for orchestrating distributed systems at any scale. It includes primitives for node discovery, raft-based consensus, task scheduling and more.
 

--- a/containerized.mk
+++ b/containerized.mk
@@ -1,6 +1,7 @@
 IMAGE_NAME=docker/swarmkit
 GOPATH=/go
 DOCKER_IMAGE_DIR=${GOPATH}/src/github.com/docker/swarmkit
+BUILDX_CMD ?= docker buildx
 
 DOCKER_SWARMKIT_DELVE_PORT ?= 2345
 
@@ -55,3 +56,20 @@ run: ensure_image_exists
 		&& DOCKER_RUN_COMMAND+=" $$DOCKER_SWARMKIT_DOCKER_RUN_FLAGS $$DOCKER_SWARMKIT_EXTRA_RUN_FLAGS ${IMAGE_NAME} $$DOCKER_SWARMKIT_DOCKER_RUN_CMD" \
 		&& echo $$DOCKER_RUN_COMMAND \
 		&& eval $$DOCKER_RUN_COMMAND
+
+# use buildx/bake for the following targets
+.PHONY: fmt-proto
+fmt-proto:
+	$(BUILDX_CMD) bake fmt-proto
+
+.PHONY: lint
+lint:
+	$(BUILDX_CMD) bake lint
+
+.PHONY: vendor-validate
+vendor-validate:
+	$(BUILDX_CMD) bake vendor-validate
+
+.PHONY: generate-validate
+generate-validate:
+	$(BUILDX_CMD) bake generate-validate

--- a/direct.mk
+++ b/direct.mk
@@ -16,6 +16,7 @@ COMMANDS=swarmd swarmctl swarm-bench swarm-rafttool protoc-gen-gogoswarm
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
+GO_TESTFLAGS=--timeout=20m $(RACE)
 
 GOBIN=$(shell go env GOPATH)/bin
 
@@ -79,12 +80,12 @@ build: ## build the go packages
 .PHONY: test
 test: ## run tests, except integration tests
 	@echo "🐳 $@"
-	@go test -parallel 8 ${RACE} -tags "${DOCKER_BUILDTAGS}" $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES})
+	@go test -parallel 8 ${GO_TESTFLAGS} -tags "${DOCKER_BUILDTAGS}" $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES})
 
 .PHONY: integration-tests
 integration-tests: ## run integration tests
 	@echo "🐳 $@"
-	@go test -parallel 8 ${RACE} -tags "${DOCKER_BUILDTAGS}" ${INTEGRATION_PACKAGE}
+	@go test -parallel 8 ${GO_TESTFLAGS} -tags "${DOCKER_BUILDTAGS}" ${INTEGRATION_PACKAGE}
 
 # Build a binary from a cmd.
 bin/%: cmd/% .FORCE
@@ -118,13 +119,13 @@ uninstall:
 coverage: ## generate coverprofiles from the unit tests
 	@echo "🐳 $@"
 	@( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}); do \
-		go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" $$pkg)/coverage.txt" -covermode=atomic $$pkg || exit; \
+		go test ${GO_TESTFLAGS} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" $$pkg)/coverage.txt" -covermode=atomic $$pkg || exit; \
 	done )
 
 .PHONY: coverage-integration
 coverage-integration: ## generate coverprofiles from the integration tests
 	@echo "🐳 $@"
-	go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" ${INTEGRATION_PACKAGE})/coverage.txt" -covermode=atomic ${INTEGRATION_PACKAGE}
+	go test ${GO_TESTFLAGS} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="$$(go list -f "{{.Dir}}" ${INTEGRATION_PACKAGE})/coverage.txt" -covermode=atomic ${INTEGRATION_PACKAGE}
 
 .PHONY: help
 help: ## this help

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,8 @@
+variable "IMAGE_NAME" {
+  default = "moby/swarmkit"
+}
+
+target "dev" {
+  tags = [IMAGE_NAME]
+  output = ["type=docker"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,3 +6,21 @@ target "dev" {
   tags = [IMAGE_NAME]
   output = ["type=docker"]
 }
+
+group "default" {
+  targets = ["validate"]
+}
+
+group "validate" {
+  targets = ["generate-validate"]
+}
+
+target "generate-validate" {
+  target = "generate-validate"
+  output = ["type=cacheonly"]
+}
+
+target "generate" {
+  target = "generate-update"
+  output = ["."]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,7 +12,17 @@ group "default" {
 }
 
 group "validate" {
-  targets = ["generate-validate"]
+  targets = ["vendor-validate", "generate-validate"]
+}
+
+target "vendor-validate" {
+  target = "vendor-validate"
+  output = ["type=cacheonly"]
+}
+
+target "vendor" {
+  target = "vendor-update"
+  output = ["."]
 }
 
 target "generate-validate" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,8 +15,17 @@ group "validate" {
   targets = ["lint", "vendor-validate", "generate-validate"]
 }
 
-target "lint" {
+group "lint" {
+  targets = ["golangci-lint", "fmt-proto"]
+}
+
+target "golangci-lint" {
   target = "lint"
+  output = ["type=cacheonly"]
+}
+
+target "fmt-proto" {
+  target = "fmt-proto"
   output = ["type=cacheonly"]
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,7 +12,12 @@ group "default" {
 }
 
 group "validate" {
-  targets = ["vendor-validate", "generate-validate"]
+  targets = ["lint", "vendor-validate", "generate-validate"]
+}
+
+target "lint" {
+  target = "lint"
+  output = ["type=cacheonly"]
 }
 
 target "vendor-validate" {


### PR DESCRIPTION
**- What I did**

Create GHA workflows to validate and run unit/integration tests. This should have the same behavior as CircleCI workflow with some enhancements to reduce build time:
* run unit/integration tests in //
* each validation (lint, fmt-proto, check protos, vendor) is also done in //

**- How I did it**

Dockerfile has been changed to handle proto, vendor, lint and fmt-proto validation so we don't need to build the whole image as it is currently. Also adds a bake definition to handle the new stages easily.

In follow-up we can remove the CircleCI workflow if we are happy with GHA ones.

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
