### PR TITLE
chore: fix invalid codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,4 @@ coverage:
         target: 0
     changes: false
 ignore:
-  -**/testutils
+  - "**/testutils"


### PR DESCRIPTION
`codecov.yml` config is invalid: https://app.codecov.io/gh/moby/swarmkit/commit/481f030e3561065657b091b6588d01e97916ff4b

```
$ curl --data-binary @codecov.yml https://codecov.io/validate
Error at ['ignore']: 
must be of list type
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>