### PR TITLE
Fix removing tasks when a jobs service is removed

### DIFF
--- a/manager/orchestrator/jobs/orchestrator.go
+++ b/manager/orchestrator/jobs/orchestrator.go
@@ -201,6 +201,11 @@ func (o *Orchestrator) handleEvent(ctx context.Context, event events.Event) {
 		service = ev.Service
 	case api.EventUpdateService:
 		service = ev.Service
+	case api.EventDeleteService:
+		if orchestrator.IsReplicatedJob(ev.Service) || orchestrator.IsGlobalJob(ev.Service) {
+			orchestrator.SetServiceTasksRemove(ctx, o.store, ev.Service)
+			o.restartSupervisor.ClearServiceHistory(ev.Service.ID)
+		}
 	case api.EventUpdateTask:
 		task = ev.Task
 	}


### PR DESCRIPTION
Previously, the jobs orchestrators were missing the appropriate code to handle the deletion of a service. As a result, when a service was deleted, the tasks for that service would hang around indefinitely. It's likely that on a leadership change or restart, the tasks would have been deleted, but that's generally not an acceptable process as leadership changes or restarts aren't guaranteed.

Fixes this issue by adding event handling for services, similar to global or replicated services, that moves all tasks for a deleted service into Remove state, flagging them for deletion.