### PR TITLE
CSI: Allow NodePublishVolume even when plugin does not support staging

### DIFF
--- a/agent/csi/plugin/plugin.go
+++ b/agent/csi/plugin/plugin.go
@@ -296,14 +296,15 @@ func (np *nodePlugin) NodePublishVolume(ctx context.Context, req *api.VolumeAssi
 
 	publishTarget := publishPath(req)
 
-	// some volumes do not require staging. we can check this by checkign the
-	// staging variable, or we can just see if there is a staging path in the
-	// map.
+	// Some volumes plugins require staging; we track this with a boolean, which
+	// also implies a staging path in the path map. If the plugin is marked as
+	// requiring staging but does not have a staging path in the map, that is an
+	// error.
 	var stagingPath string
 	if vs, ok := np.volumeMap[req.ID]; ok {
 		stagingPath = vs.stagingPath
-	} else {
-		return status.Error(codes.FailedPrecondition, "volume not staged")
+	} else if np.staging {
+		return status.Error(codes.FailedPrecondition, "volume requires staging but was not staged")
 	}
 
 	c, err := np.Client(ctx)

--- a/internal/csi/capability/capability.go
+++ b/internal/csi/capability/capability.go
@@ -1,0 +1,64 @@
+package capability
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/moby/swarmkit/v2/api"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func CheckArguments(req *api.VolumeAssignment) error {
+	if len(req.VolumeID) == 0 {
+		return status.Error(codes.InvalidArgument, "Volume ID missing in request")
+	}
+	if req.AccessMode == nil {
+		return status.Error(codes.InvalidArgument, "AccessMode missing in request")
+	}
+	return nil
+}
+
+func MakeCapability(am *api.VolumeAccessMode) *csi.VolumeCapability {
+	var mode csi.VolumeCapability_AccessMode_Mode
+	switch am.Scope {
+	case api.VolumeScopeSingleNode:
+		switch am.Sharing {
+		case api.VolumeSharingNone, api.VolumeSharingOneWriter, api.VolumeSharingAll:
+			mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+		case api.VolumeSharingReadOnly:
+			mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY
+		}
+	case api.VolumeScopeMultiNode:
+		switch am.Sharing {
+		case api.VolumeSharingReadOnly:
+			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+		case api.VolumeSharingOneWriter:
+			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER
+		case api.VolumeSharingAll:
+			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
+		}
+	}
+
+	capability := &csi.VolumeCapability{
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: mode,
+		},
+	}
+
+	if block := am.GetBlock(); block != nil {
+		capability.AccessType = &csi.VolumeCapability_Block{
+			// Block type is empty.
+			Block: &csi.VolumeCapability_BlockVolume{},
+		}
+	}
+
+	if mount := am.GetMount(); mount != nil {
+		capability.AccessType = &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{
+				FsType:     mount.FsType,
+				MountFlags: mount.MountFlags,
+			},
+		}
+	}
+
+	return capability
+}

--- a/manager/csi/convert.go
+++ b/manager/csi/convert.go
@@ -45,52 +45,6 @@ func makeTopology(t *api.Topology) *csi.Topology {
 	}
 }
 
-func makeCapability(am *api.VolumeAccessMode) *csi.VolumeCapability {
-	var mode csi.VolumeCapability_AccessMode_Mode
-	switch am.Scope {
-	case api.VolumeScopeSingleNode:
-		switch am.Sharing {
-		case api.VolumeSharingNone, api.VolumeSharingOneWriter, api.VolumeSharingAll:
-			mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
-		case api.VolumeSharingReadOnly:
-			mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY
-		}
-	case api.VolumeScopeMultiNode:
-		switch am.Sharing {
-		case api.VolumeSharingReadOnly:
-			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
-		case api.VolumeSharingOneWriter:
-			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER
-		case api.VolumeSharingAll:
-			mode = csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
-		}
-	}
-
-	capability := &csi.VolumeCapability{
-		AccessMode: &csi.VolumeCapability_AccessMode{
-			Mode: mode,
-		},
-	}
-
-	if block := am.GetBlock(); block != nil {
-		capability.AccessType = &csi.VolumeCapability_Block{
-			// Block type is empty.
-			Block: &csi.VolumeCapability_BlockVolume{},
-		}
-	}
-
-	if mount := am.GetMount(); mount != nil {
-		capability.AccessType = &csi.VolumeCapability_Mount{
-			Mount: &csi.VolumeCapability_MountVolume{
-				FsType:     mount.FsType,
-				MountFlags: mount.MountFlags,
-			},
-		}
-	}
-
-	return capability
-}
-
 // makeCapcityRange converts the swarmkit CapacityRange object to the
 // equivalent CSI object
 func makeCapacityRange(cr *api.CapacityRange) *csi.CapacityRange {

--- a/manager/csi/plugin.go
+++ b/manager/csi/plugin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
+	"github.com/moby/swarmkit/v2/internal/csi/capability"
 )
 
 // Plugin is the interface for a CSI controller plugin.
@@ -275,7 +276,7 @@ func (p *plugin) makeCreateVolume(v *api.Volume) *csi.CreateVolumeRequest {
 		Name:       v.Spec.Annotations.Name,
 		Parameters: v.Spec.Driver.Options,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			makeCapability(v.Spec.AccessMode),
+			capability.MakeCapability(v.Spec.AccessMode),
 		},
 		Secrets:                   secrets,
 		AccessibilityRequirements: makeTopologyRequirement(v.Spec.AccessibilityRequirements),
@@ -307,7 +308,7 @@ func (p *plugin) makeControllerPublishVolumeRequest(v *api.Volume, nodeID string
 	}
 
 	secrets := p.makeSecrets(v)
-	capability := makeCapability(v.Spec.AccessMode)
+	capability := capability.MakeCapability(v.Spec.AccessMode)
 	capability.AccessType = &csi.VolumeCapability_Mount{
 		Mount: &csi.VolumeCapability_MountVolume{},
 	}


### PR DESCRIPTION
**- What I did**
I was packing  NFS CSI for Swarm on https://github.com/olljanat/csi-plugins-for-docker-swarm/tree/master/csi-driver-nfs when noticed that it was able to create volume and folder to NFS share but mounting volume to didn't worked but instead of it ended up looping these messaged on Docker engine log:
```
INFO[2023-02-04T19:21:08.939610819+01:00] attempting to publish volume                  attempt=1 module=node/agent/csi volume.id=0f9wq7wvz41wxw81u4gfsiy55
DEBU[2023-02-04T19:21:08.939765667+01:00] staging volume succeeded, attempting to publish volume  attempt=1 module=node/agent/csi volume.id=0f9wq7wvz41wxw81u4gfsiy55
INFO[2023-02-04T19:21:08.939788029+01:00] publishing volume failed                      attempt=1 error="rpc error: code = FailedPrecondition desc = volume not staged" module=node/agent/csi volume.id=0f9wq7wvz41wxw81u4gfsiy55
```

**- How I did it**
Set `stagingPath` to empty string by default and continue logic instead of return error when plugin does not support staging.


**- How to test it**
Added another test case without staging. Manual testing can be done with linked NFS CSI plugin.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
