### PR TITLE
ci: dummy circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+# This is a dummy CircleCI config file to avoid GitHub status failures reported
+# on branches that don't use CircleCI. This file should be deleted when all
+# branches are no longer dependent on CircleCI.
+version: 2
+
+jobs:
+  dummy:
+    docker:
+      - image: busybox
+    steps:
+      - run:
+          name: "dummy"
+          command: echo "dummy job"
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - dummy


### PR DESCRIPTION
follow-up https://github.com/moby/swarmkit/pull/3117#issuecomment-1422313753

**- What I did**

Similar to https://github.com/docker/cli/pull/3444, adds a dummy CircleCI config file to avoid GitHub status failures reported on branches that don't use CircleCI. This file should be deleted when all branches are no longer dependent on CircleCI.

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
