### PR TITLE
Windows: Support local drivers internal, l2bridge and nat

### DIFF
--- a/manager/allocator/cnmallocator/drivers_network_windows.go
+++ b/manager/allocator/cnmallocator/drivers_network_windows.go
@@ -9,9 +9,14 @@ import (
 var initializers = []initializer{
 	{remote.Init, "remote"},
 	{ovmanager.Init, "overlay"},
+	{StubManagerInit("internal"), "internal"},
+	{StubManagerInit("l2bridge"), "l2bridge"},
+	{StubManagerInit("nat"), "nat"},
 }
 
 // PredefinedNetworks returns the list of predefined network structures
 func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
-	return nil
+	return []networkallocator.PredefinedNetworkData{
+		{Name: "nat", Driver: "nat"},
+	}
 }

--- a/manager/allocator/cnmallocator/manager.go
+++ b/manager/allocator/cnmallocator/manager.go
@@ -1,0 +1,94 @@
+package cnmallocator
+
+import (
+	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/discoverapi"
+	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/types"
+)
+
+type manager struct {
+	networkType string
+}
+
+func StubManagerInit(networkType string) func(dc driverapi.DriverCallback, config map[string]interface{}) error {
+	return func(dc driverapi.DriverCallback, config map[string]interface{}) error {
+		return RegisterManager(dc, networkType)
+	}
+}
+
+// Register registers a new instance of the manager driver for networkType with r.
+func RegisterManager(r driverapi.DriverCallback, networkType string) error {
+	c := driverapi.Capability{
+		DataScope:         datastore.LocalScope,
+		ConnectivityScope: datastore.LocalScope,
+	}
+	return r.RegisterDriver(networkType, &manager{networkType: networkType}, c)
+}
+
+func (d *manager) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
+	return nil, types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) NetworkFree(id string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {
+}
+
+func (d *manager) DecodeTableEntry(tablename string, key string, value []byte) (string, map[string]string) {
+	return "", nil
+}
+
+func (d *manager) DeleteNetwork(nid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) DeleteEndpoint(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
+	return nil, types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Leave(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) Type() string {
+	return d.networkType
+}
+
+func (d *manager) IsBuiltIn() bool {
+	return true
+}
+
+func (d *manager) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+	return types.NotImplementedErrorf("not implemented")
+}
+
+func (d *manager) RevokeExternalConnectivity(nid, eid string) error {
+	return types.NotImplementedErrorf("not implemented")
+}


### PR DESCRIPTION
**- What I did**
This PR takes generic driver manager which @corhere built on https://github.com/moby/moby/pull/44983 and includes it to Swarmkit instead of libnetwork like proposed on https://github.com/moby/moby/pull/44983#discussion_r1106200444

In additionally that driver manager is used to register `internal` , `nat` and `l2bridge` drivers for Windows so scenarios explained on https://github.com/moby/moby/pull/44983 can be solved.

**- How I did it**
Copy/paste from that another PR, minimal refactoring to existing code to support it and revendor to remove libnetwork code which is not needed here anymore.

**- How to test it**
If we get CI to 🟢 it should enough.

**- Description for the changelog**

