### PR TITLE
CSI: Manager PublishVolume verify CSI node ID is not empty

### DIFF
--- a/manager/csi/plugin_test.go
+++ b/manager/csi/plugin_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Plugin manager", func() {
 				PublishStatus: []*api.VolumePublishStatus{
 					{
 						State:  api.VolumePublishStatus_PENDING_PUBLISH,
-						NodeID: "node1",
+						NodeID: "swarmNode1",
 					},
 				},
 			}
@@ -318,7 +318,7 @@ var _ = Describe("Plugin manager", func() {
 		})
 
 		JustBeforeEach(func() {
-			publishContext, publishError = plugin.PublishVolume(context.Background(), v, "node1")
+			publishContext, publishError = plugin.PublishVolume(context.Background(), v, "swarmNode1")
 		})
 
 		It("should call the ControllerPublishVolume RPC", func() {


### PR DESCRIPTION
**- What I did**
When I was working on to packaging DigitalOcean CSI driver for Swarm in https://github.com/olljanat/csi-plugins-for-docker-swarm/pull/15 I found that PublishVolume gets called before Node ID value is stored.

Returning error on this case looks to trigger Swarm logic to trying publish again until it works. 

However it looks to be that Docker engine need to be restarted once after plugin was installed before NodeID have value so there is more work need ton this area.

**- How I did it**
Implemented simple value check. Also added separate error message logging because it looks to be that error returned by `PublishVolume` does not appear to log.

**- How to test it**
Should be fine as long it passes CI.

**- Description for the changelog**
