### PR TITLE
manager/allocator/cnmallocator: remove uses of deprecated Init() funcs

### DIFF
--- a/manager/allocator/cnmallocator/drivers.go
+++ b/manager/allocator/cnmallocator/drivers.go
@@ -1,0 +1,25 @@
+package cnmallocator
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/drivers/remote"
+)
+
+type driverRegisterFn func(r driverapi.Registerer, config map[string]interface{}) error
+
+func registerRemote(r driverapi.Registerer, _ map[string]interface{}) error {
+	dc, ok := r.(driverapi.DriverCallback)
+	if !ok {
+		return fmt.Errorf(`failed to register "remote" driver: driver does not implement driverapi.DriverCallback`)
+	}
+	return remote.Register(dc, dc.GetPluginGetter())
+}
+
+//nolint:unused // is currently only used on Windows, but keeping these adaptors together in one file.
+func registerNetworkType(networkType string) func(dc driverapi.Registerer, config map[string]interface{}) error {
+	return func(r driverapi.Registerer, _ map[string]interface{}) error {
+		return RegisterManager(r, networkType)
+	}
+}

--- a/manager/allocator/cnmallocator/drivers_darwin.go
+++ b/manager/allocator/cnmallocator/drivers_darwin.go
@@ -2,13 +2,12 @@ package cnmallocator
 
 import (
 	"github.com/docker/docker/libnetwork/drivers/overlay/ovmanager"
-	"github.com/docker/docker/libnetwork/drivers/remote"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
 var initializers = map[string]driverRegisterFn{
-	"remote":  remote.Init,
-	"overlay": ovmanager.Init,
+	"remote":  registerRemote,
+	"overlay": ovmanager.Register,
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/drivers_darwin.go
+++ b/manager/allocator/cnmallocator/drivers_darwin.go
@@ -6,9 +6,9 @@ import (
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
-var initializers = []initializer{
-	{remote.Init, "remote"},
-	{ovmanager.Init, "overlay"},
+var initializers = map[string]driverRegisterFn{
+	"remote":  remote.Init,
+	"overlay": ovmanager.Init,
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/drivers_network_linux.go
+++ b/manager/allocator/cnmallocator/drivers_network_linux.go
@@ -7,16 +7,17 @@ import (
 	"github.com/docker/docker/libnetwork/drivers/macvlan/mvmanager"
 	"github.com/docker/docker/libnetwork/drivers/overlay/ovmanager"
 	"github.com/docker/docker/libnetwork/drivers/remote"
+	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
-var initializers = []initializer{
-	{remote.Init, "remote"},
-	{ovmanager.Init, "overlay"},
-	{mvmanager.Init, "macvlan"},
-	{brmanager.Init, "bridge"},
-	{ivmanager.Init, "ipvlan"},
-	{host.Init, "host"},
+var initializers = map[string]drvregistry.InitFunc{
+	"remote":  remote.Init,
+	"overlay": ovmanager.Init,
+	"macvlan": mvmanager.Init,
+	"bridge":  brmanager.Init,
+	"ipvlan":  ivmanager.Init,
+	"host":    host.Init,
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/drivers_network_linux.go
+++ b/manager/allocator/cnmallocator/drivers_network_linux.go
@@ -6,18 +6,16 @@ import (
 	"github.com/docker/docker/libnetwork/drivers/ipvlan/ivmanager"
 	"github.com/docker/docker/libnetwork/drivers/macvlan/mvmanager"
 	"github.com/docker/docker/libnetwork/drivers/overlay/ovmanager"
-	"github.com/docker/docker/libnetwork/drivers/remote"
-	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
-var initializers = map[string]drvregistry.InitFunc{
-	"remote":  remote.Init,
-	"overlay": ovmanager.Init,
-	"macvlan": mvmanager.Init,
-	"bridge":  brmanager.Init,
-	"ipvlan":  ivmanager.Init,
-	"host":    host.Init,
+var initializers = map[string]driverRegisterFn{
+	"remote":  registerRemote,
+	"overlay": ovmanager.Register,
+	"macvlan": mvmanager.Register,
+	"bridge":  brmanager.Register,
+	"ipvlan":  ivmanager.Register,
+	"host":    host.Register,
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/drivers_network_windows.go
+++ b/manager/allocator/cnmallocator/drivers_network_windows.go
@@ -3,15 +3,16 @@ package cnmallocator
 import (
 	"github.com/docker/docker/libnetwork/drivers/overlay/ovmanager"
 	"github.com/docker/docker/libnetwork/drivers/remote"
+	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
-var initializers = []initializer{
-	{remote.Init, "remote"},
-	{ovmanager.Init, "overlay"},
-	{StubManagerInit("internal"), "internal"},
-	{StubManagerInit("l2bridge"), "l2bridge"},
-	{StubManagerInit("nat"), "nat"},
+var initializers = map[string]drvregistry.InitFunc{
+	"remote":   remote.Init,
+	"overlay":  ovmanager.Init,
+	"internal": StubManagerInit("internal"),
+	"l2bridge": StubManagerInit("l2bridge"),
+	"nat":      StubManagerInit("nat"),
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/drivers_network_windows.go
+++ b/manager/allocator/cnmallocator/drivers_network_windows.go
@@ -2,17 +2,15 @@ package cnmallocator
 
 import (
 	"github.com/docker/docker/libnetwork/drivers/overlay/ovmanager"
-	"github.com/docker/docker/libnetwork/drivers/remote"
-	"github.com/docker/docker/libnetwork/drvregistry"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 )
 
-var initializers = map[string]drvregistry.InitFunc{
-	"remote":   remote.Init,
-	"overlay":  ovmanager.Init,
-	"internal": StubManagerInit("internal"),
-	"l2bridge": StubManagerInit("l2bridge"),
-	"nat":      StubManagerInit("nat"),
+var initializers = map[string]driverRegisterFn{
+	"remote":   registerRemote,
+	"overlay":  ovmanager.Register,
+	"internal": registerNetworkType("internal"),
+	"l2bridge": registerNetworkType("l2bridge"),
+	"nat":      registerNetworkType("nat"),
 }
 
 // PredefinedNetworks returns the list of predefined network structures

--- a/manager/allocator/cnmallocator/manager.go
+++ b/manager/allocator/cnmallocator/manager.go
@@ -17,13 +17,12 @@ func StubManagerInit(networkType string) func(dc driverapi.DriverCallback, confi
 	}
 }
 
-// Register registers a new instance of the manager driver for networkType with r.
-func RegisterManager(r driverapi.DriverCallback, networkType string) error {
-	c := driverapi.Capability{
+// RegisterManager registers a new instance of the manager driver for networkType with r.
+func RegisterManager(r driverapi.Registerer, networkType string) error {
+	return r.RegisterDriver(networkType, &manager{networkType: networkType}, driverapi.Capability{
 		DataScope:         datastore.LocalScope,
 		ConnectivityScope: datastore.LocalScope,
-	}
-	return r.RegisterDriver(networkType, &manager{networkType: networkType}, c)
+	})
 }
 
 func (d *manager) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {

--- a/manager/allocator/cnmallocator/manager.go
+++ b/manager/allocator/cnmallocator/manager.go
@@ -11,8 +11,8 @@ type manager struct {
 	networkType string
 }
 
-func StubManagerInit(networkType string) func(dc driverapi.DriverCallback, config map[string]interface{}) error {
-	return func(dc driverapi.DriverCallback, config map[string]interface{}) error {
+func StubManagerInit(networkType string) func(dc driverapi.DriverCallback, _ map[string]interface{}) error {
+	return func(dc driverapi.DriverCallback, _ map[string]interface{}) error {
 		return RegisterManager(dc, networkType)
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44875
- [x] depends on https://github.com/moby/swarmkit/pull/3140

### cnmallocator: RegisterManager does not require DriverCallback interface

This function was not using the DriverCallback interface, and only
required the Registerer interface.

### manager/allocator/cnmallocator: use a map for initializers

Refactor the initializers slice to be a map (as driver-names should be
unique, and they were not dynamically set here either way).

Also inlining the code from initializeDrivers(), as it was only used
in a single location, and the code lived far from where it was used.

### manager/allocator/cnmallocator: remove uses of deprecated Init() funcs

These functions were deprecated in https://github.com/moby/moby/commit/28edc8e2d692cb47f1ec6bb32a6e346777e1250d (https://github.com/moby/moby/pull/44875)
in favor of the Register functions.

Unfortunately, not all Register functions have the same signature, so
some (temporary) adaptor code was needed for these.

### manager/allocator/cnmallocator: StubManagerInit: config arg is unused

Make it clearer that the config argument is not used.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
