### PR TITLE
manager/allocator/cnmallocator: add temporary adaptor for constructor

### DIFF
--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -99,6 +99,23 @@ type NetworkConfig struct {
 	VXLANUDPPort uint32
 }
 
+type (
+	registryConstructor = func(drvregistry.DriverNotifyFunc, plugingetter.PluginGetter) (*drvregistry.DrvRegistry, error)
+	legacyConstructor   = func(drvregistry.Placeholder, drvregistry.Placeholder, drvregistry.DriverNotifyFunc, drvregistry.Placeholder, plugingetter.PluginGetter) (*drvregistry.DrvRegistry, error)
+)
+
+func newDriverRegistry(newFn any, pg plugingetter.PluginGetter) (*drvregistry.DrvRegistry, error) {
+	switch fn := newFn.(type) {
+	case registryConstructor:
+		// There are no notification functions as of now.
+		return fn(nil, pg)
+	case legacyConstructor:
+		return fn(nil, nil, nil, nil, pg)
+	default:
+		return nil, fmt.Errorf("invalid constructor signature: %T", newFn)
+	}
+}
+
 // New returns a new NetworkAllocator handle
 func New(pg plugingetter.PluginGetter, netConfig *NetworkConfig) (networkallocator.NetworkAllocator, error) {
 	na := &cnmNetworkAllocator{
@@ -108,9 +125,8 @@ func New(pg plugingetter.PluginGetter, netConfig *NetworkConfig) (networkallocat
 		nodes:    make(map[string]map[string]struct{}),
 	}
 
-	// There are no driver configurations and notification
-	// functions as of now.
-	reg, err := drvregistry.New(nil, nil, nil, nil, pg)
+	// FIXME(thaJeztah): drvregistry.New was deprecated in https://github.com/moby/moby/commit/5595311209cc915e8b0ace0a1bbd8b52a7baecb0, but there's no other way to pass a PluginGetter to it.
+	reg, err := newDriverRegistry(drvregistry.New, pg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- possible alternative to https://github.com/moby/moby/pull/45843
- relates to / supersedes / closes https://github.com/moby/swarmkit/pull/3130
- supersedes / closes https://github.com/moby/swarmkit/pull/3015

Add an adaptor to help with a signature change in the Idm constructor.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
