### PR TITLE
Free unused volumes in more cases

### DIFF
--- a/manager/scheduler/volumes_test.go
+++ b/manager/scheduler/volumes_test.go
@@ -652,9 +652,7 @@ var _ = Describe("volumeSet", func() {
 			vs.releaseVolume(volumes[0].ID, tasks[0].ID)
 			vs.releaseVolume(allVolume.ID, tasks[0].ID)
 
-			err := s.Update(func(tx store.Tx) error {
-				return vs.freeVolumes(tx)
-			})
+			err := s.Batch(vs.freeVolumes)
 			Expect(err).ToNot(HaveOccurred())
 
 			var freshVolumes []*api.Volume


### PR DESCRIPTION
**- What I did**

Freeing volumes is only done on scheduling ticks, but not every scheduling tick resulted in freeing volumes. This change makes it so that volumes are freed every time a scheduling tick happens, regardless of whether there were any scheduled task changes.

**- How I did it**

See comments in code
