### PR TITLE
A previously running task on a node with state "down" should not be l…

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -1112,7 +1112,9 @@ func (s *Server) ListServiceStatuses(ctx context.Context, req *api.ListServiceSt
 						status.CompletedTasks++
 					}
 				}
-				if task.Status.State == api.TaskStateRunning {
+				// report as running only if the task's node is up
+				node := store.GetNode(tx, task.NodeID)
+				if node != nil && node.Status.State != api.NodeStatus_DOWN && task.Status.State == api.TaskStateRunning {
 					status.RunningTasks++
 				}
 


### PR DESCRIPTION
The docker service ls command on a manager would report previously running tasks on a node that went down as running.
I updated the ListServiceStatuses function not to include these tasks in the output for running tasks
Fixes #45922

**- What I did**
I changed the listing of service statuses.

**- How I did it**
I checked if the node the service task is running on is down, and only if it's not, I upped the counter for running tasks.

**- How to test it**
Use the description of the related issue or run the test ListServiceStatuses in services_test.go

**- Description for the changelog**
Exclude tasks on non-responding nodes from the service status ouput.
