### PR TITLE
reduce direct imports of logrus

### DIFF
--- a/agent/csi/volumes.go
+++ b/agent/csi/volumes.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/docker/docker/pkg/plugingetter"
 
 	"github.com/moby/swarmkit/v2/agent/csi/plugin"
@@ -65,7 +63,7 @@ func (r *volumes) retryVolumes() {
 	for {
 		vid, attempt := r.pendingVolumes.Wait()
 
-		dctx := log.WithFields(ctx, logrus.Fields{
+		dctx := log.WithFields(ctx, log.Fields{
 			"volume.id": vid,
 			"attempt":   fmt.Sprintf("%d", attempt),
 		})

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/protobuf/ptypes"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Controller controls execution of a task.
@@ -348,11 +347,10 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 
 func logStateChange(ctx context.Context, desired, previous, next api.TaskState) {
 	if previous != next {
-		fields := logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"state.transition": fmt.Sprintf("%v->%v", previous, next),
 			"state.desired":    desired,
-		}
-		log.G(ctx).WithFields(fields).Debug("state changed")
+		}).Debug("state changed")
 	}
 }
 

--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -17,7 +17,6 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 )
 
@@ -84,13 +83,13 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 			// if we have progress details, we have everything we need
 			if progress, ok := m["progressDetail"].(map[string]interface{}); ok {
 				// first, log the image and status
-				l = l.WithFields(logrus.Fields{
+				l = l.WithFields(log.Fields{
 					"image":  c.container.image(),
 					"status": m["status"],
 				})
 				// then, if we have progress, log the progress
 				if progress["current"] != nil && progress["total"] != nil {
-					l = l.WithFields(logrus.Fields{
+					l = l.WithFields(log.Fields{
 						"current": progress["current"],
 						"total":   progress["total"],
 					})

--- a/agent/session.go
+++ b/agent/session.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/connectionbroker"
 	"github.com/moby/swarmkit/v2/log"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -180,7 +179,7 @@ func (s *session) heartbeat(ctx context.Context) error {
 	heartbeat := time.NewTimer(1) // send out a heartbeat right away
 	defer heartbeat.Stop()
 
-	fields := logrus.Fields{
+	fields := log.Fields{
 		"sessionID": s.sessionID,
 		"method":    "(*session).heartbeat",
 	}
@@ -243,8 +242,8 @@ func (s *session) handleSessionMessage(ctx context.Context, msg *api.SessionMess
 }
 
 func (s *session) logSubscriptions(ctx context.Context) error {
-	log := log.G(ctx).WithFields(logrus.Fields{"method": "(*session).logSubscriptions"})
-	log.Debugf("")
+	logger := log.G(ctx).WithFields(log.Fields{"method": "(*session).logSubscriptions"})
+	logger.Debugf("")
 
 	client := api.NewLogBrokerClient(s.conn.ClientConn)
 	subscriptions, err := client.ListenSubscriptions(ctx, &api.ListenSubscriptionsRequest{})
@@ -257,7 +256,7 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 		resp, err := subscriptions.Recv()
 		st, _ := status.FromError(err)
 		if st.Code() == codes.Unimplemented {
-			log.Warning("manager does not support log subscriptions")
+			logger.Warning("manager does not support log subscriptions")
 			// Don't return, because returning would bounce the session
 			select {
 			case <-s.closed:
@@ -281,8 +280,8 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 }
 
 func (s *session) watch(ctx context.Context) error {
-	log := log.G(ctx).WithFields(logrus.Fields{"method": "(*session).watch"})
-	log.Debugf("")
+	logger := log.G(ctx).WithFields(log.Fields{"method": "(*session).watch"})
+	logger.Debugf("")
 	var (
 		resp            *api.AssignmentsMessage
 		assignmentWatch api.Dispatcher_AssignmentsClient
@@ -313,7 +312,7 @@ func (s *session) watch(ctx context.Context) error {
 				}
 				tasksFallback = true
 				assignmentWatch = nil
-				log.WithError(err).Infof("falling back to Tasks")
+				logger.WithError(err).Infof("falling back to Tasks")
 			}
 		}
 

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/api"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/swarmkit/v2/log"
 	"github.com/stretchr/testify/assert"
 )
 
+const debugLevel = 5
+
 func init() {
-	logrus.SetLevel(logrus.DebugLevel)
+	log.L.Logger.SetLevel(debugLevel)
 }
 
 func TestTaskManager(t *testing.T) {

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/watch"
-	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -135,7 +134,7 @@ func (w *worker) Assign(ctx context.Context, assignments []*api.AssignmentChange
 		return ErrClosed
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(assignments)": len(assignments),
 	}).Debug("(*worker).Assign")
 
@@ -174,7 +173,7 @@ func (w *worker) Update(ctx context.Context, assignments []*api.AssignmentChange
 		return ErrClosed
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(assignments)": len(assignments),
 	}).Debug("(*worker).Update")
 
@@ -212,7 +211,7 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 		}
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(updatedTasks)": len(updatedTasks),
 		"len(removedTasks)": len(removedTasks),
 	}).Debug("(*worker).reconcileTaskState")
@@ -227,10 +226,10 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 	assigned := map[string]struct{}{}
 
 	for _, task := range updatedTasks {
-		log.G(ctx).WithFields(
-			logrus.Fields{
-				"task.id":           task.ID,
-				"task.desiredstate": task.DesiredState}).Debug("assigned")
+		log.G(ctx).WithFields(log.Fields{
+			"task.id":           task.ID,
+			"task.desiredstate": task.DesiredState,
+		}).Debug("assigned")
 		if err := PutTask(tx, task); err != nil {
 			return err
 		}
@@ -359,7 +358,7 @@ func reconcileSecrets(ctx context.Context, w *worker, assignments []*api.Assignm
 
 	secrets := secretsProvider.Secrets()
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(updatedSecrets)": len(updatedSecrets),
 		"len(removedSecrets)": len(removedSecrets),
 	}).Debug("(*worker).reconcileSecrets")
@@ -402,7 +401,7 @@ func reconcileConfigs(ctx context.Context, w *worker, assignments []*api.Assignm
 
 	configs := configsProvider.Configs()
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(updatedConfigs)": len(updatedConfigs),
 		"len(removedConfigs)": len(removedConfigs),
 	}).Debug("(*worker).reconcileConfigs")
@@ -448,7 +447,7 @@ func reconcileVolumes(ctx context.Context, w *worker, assignments []*api.Assignm
 
 	volumes := volumesProvider.Volumes()
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"len(updatedVolumes)": len(updatedVolumes),
 		"len(removedVolumes)": len(removedVolumes),
 	}).Debug("(*worker).reconcileVolumes")
@@ -536,7 +535,7 @@ func (w *worker) taskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (
 }
 
 func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (*taskManager, error) {
-	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
 		"task.id":    task.ID,
 		"service.id": task.ServiceID,
 	}))

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	bolt "go.etcd.io/bbolt"
 )
@@ -20,7 +19,7 @@ type testPublisherProvider struct {
 
 func (tpp *testPublisherProvider) Publisher(ctx context.Context, subscriptionID string) (exec.LogPublisher, func(), error) {
 	return exec.LogPublisherFunc(func(ctx context.Context, message api.LogMessage) error {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"subscription": subscriptionID,
 				"task.id":      message.Context.TaskID,
 				"node.id":      message.Context.NodeID,
@@ -61,7 +60,7 @@ func TestWorkerAssign(t *testing.T) {
 	worker := newWorker(db, executor, &testPublisherProvider{})
 	reporter := newFakeReporter(
 		statusReporterFunc(func(ctx context.Context, taskID string, status *api.TaskStatus) error {
-			log.G(ctx).WithFields(logrus.Fields{"task.id": taskID, "status": status}).Info("status update received")
+			log.G(ctx).WithFields(log.Fields{"task.id": taskID, "status": status}).Info("status update received")
 			return nil
 		}),
 		volumeReporterFunc(func(ctx context.Context, volumeID string) error {
@@ -282,7 +281,7 @@ func TestWorkerWait(t *testing.T) {
 	worker := newWorker(db, executor, &testPublisherProvider{})
 	reporter := newFakeReporter(
 		statusReporterFunc(func(ctx context.Context, taskID string, status *api.TaskStatus) error {
-			log.G(ctx).WithFields(logrus.Fields{"task.id": taskID, "status": status}).Info("status update received")
+			log.G(ctx).WithFields(log.Fields{"task.id": taskID, "status": status}).Info("status update received")
 			return nil
 		}),
 		volumeReporterFunc(func(ctx context.Context, volumeID string) error {
@@ -433,7 +432,7 @@ func TestWorkerUpdate(t *testing.T) {
 	worker := newWorker(db, executor, &testPublisherProvider{})
 	reporter := newFakeReporter(
 		statusReporterFunc(func(ctx context.Context, taskID string, status *api.TaskStatus) error {
-			log.G(ctx).WithFields(logrus.Fields{"task.id": taskID, "status": status}).Info("status update received")
+			log.G(ctx).WithFields(log.Fields{"task.id": taskID, "status": status}).Info("status update received")
 			return nil
 		}),
 		volumeReporterFunc(func(ctx context.Context, volumeID string) error {

--- a/ca/auth.go
+++ b/ca/auth.go
@@ -6,8 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
 	"google.golang.org/grpc/codes"
@@ -43,7 +41,7 @@ func LogTLSState(ctx context.Context, tlsState *tls.ConnectionState) {
 		verifiedChain = append(verifiedChain, strings.Join(subjects, ","))
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"peer.peerCert": peerCerts,
 		// "peer.verifiedChain": verifiedChain},
 	}).Debugf("")

--- a/ca/config.go
+++ b/ca/config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/moby/swarmkit/v2/watch"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -463,7 +462,7 @@ func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter, 
 		PublicKey: issuer.RawSubjectPublicKeyInfo,
 	})
 	if err == nil {
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id":   secConfig.ClientTLSCreds.NodeID(),
 			"node.role": secConfig.ClientTLSCreds.Role(),
 		}).Debug("loaded node credentials")
@@ -524,12 +523,12 @@ func (rootCA RootCA) CreateSecurityConfig(ctx context.Context, krw *KeyReadWrite
 			return nil, nil, err
 		}
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id":   cn,
 			"node.role": proposedRole,
 		}).Debug("issued new TLS certificate")
 	default:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id":   cn,
 			"node.role": proposedRole,
 		}).WithError(err).Errorf("failed to issue and save new certificate")
@@ -538,7 +537,7 @@ func (rootCA RootCA) CreateSecurityConfig(ctx context.Context, krw *KeyReadWrite
 
 	secConfig, cleanup, err := NewSecurityConfig(&rootCA, krw, tlsKeyPair, issuerInfo)
 	if err == nil {
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id":   secConfig.ClientTLSCreds.NodeID(),
 			"node.role": secConfig.ClientTLSCreds.Role(),
 		}).Debugf("new node credentials generated: %s", krw.Target())
@@ -579,7 +578,7 @@ func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, connBroker *conne
 	defer s.renewalMu.Unlock()
 
 	ctx = log.WithModule(ctx, "tls")
-	log := log.G(ctx).WithFields(logrus.Fields{
+	logger := log.G(ctx).WithFields(log.Fields{
 		"node.id":   s.ClientTLSCreds.NodeID(),
 		"node.role": s.ClientTLSCreds.Role(),
 	})
@@ -602,7 +601,7 @@ func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, connBroker *conne
 		}
 	}
 	if err != nil {
-		log.WithError(err).Errorf("failed to renew the certificate")
+		logger.WithError(err).Errorf("failed to renew the certificate")
 		return err
 	}
 

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/moby/swarmkit/v2/testutils"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -322,7 +321,7 @@ func TestLoadSecurityConfigIntermediates(t *testing.T) {
 	rootCA, err := ca.NewRootCA(cautils.ECDSACertChain[2], nil, nil, ca.DefaultNodeCertExpiration, nil)
 	require.NoError(t, err)
 
-	ctx := log.WithLogger(context.Background(), log.L.WithFields(logrus.Fields{
+	ctx := log.WithLogger(context.Background(), log.L.WithFields(log.Fields{
 		"testname":          t.Name(),
 		"testHasExternalCA": false,
 	}))
@@ -360,7 +359,7 @@ func TestLoadSecurityConfigKeyFormat(t *testing.T) {
 	rootCA, err := ca.NewRootCA(cautils.ECDSACertChain[1], nil, nil, ca.DefaultNodeCertExpiration, nil)
 	require.NoError(t, err)
 
-	ctx := log.WithLogger(context.Background(), log.L.WithFields(logrus.Fields{
+	ctx := log.WithLogger(context.Background(), log.L.WithFields(log.Fields{
 		"testname":          t.Name(),
 		"testHasExternalCA": false,
 	}))

--- a/ca/external.go
+++ b/ca/external.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
 )
 
@@ -203,7 +202,7 @@ func makeExternalSignRequest(ctx context.Context, client *http.Client, url strin
 
 	var apiResponse api.Response
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		logrus.Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
+		log.G(ctx).Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to parse JSON response")}
 	}
 

--- a/ca/external_test.go
+++ b/ca/external_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/swarmkit/v2/ca"
 	"github.com/moby/swarmkit/v2/ca/testutils"
 	"github.com/moby/swarmkit/v2/log"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,7 +102,7 @@ func TestExternalCASignRequestTimesOut(t *testing.T) {
 		return // this does not require the external CA in any way
 	}
 
-	ctx := log.WithLogger(context.Background(), log.L.WithFields(logrus.Fields{
+	ctx := log.WithLogger(context.Background(), log.L.WithFields(log.Fields{
 		"testname":          t.Name(),
 		"testHasExternalCA": false,
 	}))
@@ -151,7 +150,7 @@ func TestExternalCASignRequestSizeLimit(t *testing.T) {
 		return // this does not require the external CA in any way
 	}
 
-	ctx := log.WithLogger(context.Background(), log.L.WithFields(logrus.Fields{
+	ctx := log.WithLogger(context.Background(), log.L.WithFields(log.Fields{
 		"testname":          t.Name(),
 		"testHasExternalCA": false,
 	}))

--- a/ca/server.go
+++ b/ca/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -182,7 +181,7 @@ func (s *Server) NodeCertificateStatus(ctx context.Context, request *api.NodeCer
 		return nil, status.Errorf(codes.NotFound, codes.NotFound.String())
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"node.id": node.ID,
 		"status":  node.Certificate.Status,
 		"method":  "NodeCertificateStatus",
@@ -196,7 +195,7 @@ func (s *Server) NodeCertificateStatus(ctx context.Context, request *api.NodeCer
 		}, nil
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"node.id": node.ID,
 		"status":  node.Certificate.Status,
 		"method":  "NodeCertificateStatus",
@@ -326,7 +325,7 @@ func (s *Server) IssueNodeCertificate(ctx context.Context, request *api.IssueNod
 			return store.CreateNode(tx, node)
 		})
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"node.id":   nodeID,
 				"node.role": role,
 				"method":    "IssueNodeCertificate",
@@ -339,7 +338,7 @@ func (s *Server) IssueNodeCertificate(ctx context.Context, request *api.IssueNod
 		if i == maxRetries {
 			return nil, err
 		}
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id":   nodeID,
 			"node.role": role,
 			"method":    "IssueNodeCertificate",
@@ -363,7 +362,7 @@ func (s *Server) issueRenewCertificate(ctx context.Context, nodeID string, csr [
 		// Attempt to retrieve the node with nodeID
 		node = store.GetNode(tx, nodeID)
 		if node == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"node.id": nodeID,
 				"method":  "issueRenewCertificate",
 			}).Warnf("node does not exist")
@@ -388,7 +387,7 @@ func (s *Server) issueRenewCertificate(ctx context.Context, nodeID string, csr [
 		return nil, err
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"cert.cn":   cert.CN,
 		"cert.role": cert.Role,
 		"method":    "issueRenewCertificate",
@@ -404,7 +403,7 @@ func (s *Server) issueRenewCertificate(ctx context.Context, nodeID string, csr [
 // the root of trust for the swarm. Clients should be using the CA hash to verify if they weren't target to
 // a MiTM. If they fail to do so, node bootstrap works with TOFU semantics.
 func (s *Server) GetRootCACertificate(ctx context.Context, request *api.GetRootCACertificateRequest) (*api.GetRootCACertificateResponse, error) {
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"method": "GetRootCACertificate",
 	})
 
@@ -477,7 +476,7 @@ func (s *Server) Run(ctx context.Context) error {
 	s.mu.Unlock()
 
 	if err != nil {
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"method": "(*Server).Run",
 		}).WithError(err).Errorf("snapshot store view failed")
 		return err
@@ -489,7 +488,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := s.reconcileNodeCertificates(ctx, nodes); err != nil {
 		// We don't return here because that means the Run loop would
 		// never run. Log an error instead.
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"method": "(*Server).Run",
 		}).WithError(err).Errorf("error attempting to reconcile certificates")
 	}
@@ -668,7 +667,7 @@ func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster, reconci
 	firstSeenCluster := s.lastSeenClusterRootCA == nil && s.lastSeenExternalCAs == nil
 	rootCAChanged := len(rCA.CACert) != 0 && !equality.RootCAEqualStable(s.lastSeenClusterRootCA, rCA)
 	externalCAChanged := !equality.ExternalCAsEqualStable(s.lastSeenExternalCAs, cluster.Spec.CAConfig.ExternalCAs)
-	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
 		"cluster.id": cluster.ID,
 		"method":     "(*Server).UpdateRootCA",
 	}))
@@ -773,7 +772,7 @@ func (s *Server) signNodeCert(ctx context.Context, node *api.Node) error {
 	// Convert the role from proto format
 	role, err := ParseRole(node.Certificate.Role)
 	if err != nil {
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id": node.ID,
 			"method":  "(*Server).signNodeCert",
 		}).WithError(err).Errorf("failed to parse role")
@@ -798,7 +797,7 @@ func (s *Server) signNodeCert(ctx context.Context, node *api.Node) error {
 	}
 
 	if err != nil {
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id": node.ID,
 			"method":  "(*Server).signNodeCert",
 		}).WithError(err).Errorf("failed to sign CSR")
@@ -830,7 +829,7 @@ func (s *Server) signNodeCert(ctx context.Context, node *api.Node) error {
 			return store.UpdateNode(tx, node)
 		})
 		if err != nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"node.id": nodeID,
 				"method":  "(*Server).signNodeCert",
 			}).WithError(err).Errorf("transaction failed when setting state to FAILED")
@@ -858,7 +857,7 @@ func (s *Server) signNodeCert(ctx context.Context, node *api.Node) error {
 			return err
 		})
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"node.id":   node.ID,
 				"node.role": node.Certificate.Role,
 				"method":    "(*Server).signNodeCert",
@@ -870,7 +869,7 @@ func (s *Server) signNodeCert(ctx context.Context, node *api.Node) error {
 			continue
 		}
 
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"node.id": nodeID,
 			"method":  "(*Server).signNodeCert",
 		}).WithError(err).Errorf("transaction failed")

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/moby/swarmkit/v2/testutils"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -1187,7 +1186,7 @@ func TestRootRotationReconciliationRace(t *testing.T) {
 		// offset each server's reconciliation interval somewhat so that some will
 		// pre-empt others
 		otherServers[i].SetRootReconciliationInterval(time.Millisecond * time.Duration((i+1)*10))
-		serverContexts[i] = log.WithLogger(tc.Context, log.G(tc.Context).WithFields(logrus.Fields{
+		serverContexts[i] = log.WithLogger(tc.Context, log.G(tc.Context).WithFields(log.Fields{
 			"otherCAServer": i,
 		}))
 		startCAServer(serverContexts[i], otherServers[i])

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -26,7 +26,6 @@ import (
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	stateutils "github.com/moby/swarmkit/v2/manager/state/testutils"
 	"github.com/moby/swarmkit/v2/remotes"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -273,7 +272,7 @@ func newTestCA(t *testing.T, tempBaseDir string, apiRootCA api.RootCA, krwGenera
 	api.RegisterCAServer(grpcServer, caServer)
 	api.RegisterNodeCAServer(grpcServer, caServer)
 
-	fields := logrus.Fields{"testHasExternalCA": External}
+	fields := log.Fields{"testHasExternalCA": External}
 	if t != nil {
 		fields["testname"] = t.Name()
 	}

--- a/cmd/external-ca-example/main.go
+++ b/cmd/external-ca-example/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/moby/swarmkit/v2/ca"
 	"github.com/moby/swarmkit/v2/ca/testutils"
 	"github.com/moby/swarmkit/v2/identity"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/swarmkit/v2/log"
 )
 
 func main() {
@@ -22,10 +22,10 @@ func main() {
 	// Initialize the Root CA.
 	rootCA, err := ca.CreateRootCA("external-ca-example")
 	if err != nil {
-		logrus.Fatalf("unable to initialize Root CA: %s", err.Error())
+		log.L.Fatalf("unable to initialize Root CA: %s", err.Error())
 	}
 	if err := ca.SaveRootCA(rootCA, rootPaths); err != nil {
-		logrus.Fatalf("unable to save Root CA: %s", err.Error())
+		log.L.Fatalf("unable to save Root CA: %s", err.Error())
 	}
 
 	// Create the initial manager node credentials.
@@ -36,7 +36,7 @@ func main() {
 
 	kw := ca.NewKeyReadWriter(nodeConfigPaths.Node, nil, nil)
 	if _, _, err := rootCA.IssueAndSaveNewCertificates(kw, nodeID, ca.ManagerRole, clusterID); err != nil {
-		logrus.Fatalf("unable to create initial manager node credentials: %s", err)
+		log.L.Fatalf("unable to create initial manager node credentials: %s", err)
 	}
 
 	// And copy the Root CA certificate into the node config path for its
@@ -45,12 +45,12 @@ func main() {
 
 	server, err := testutils.NewExternalSigningServer(rootCA, "ca")
 	if err != nil {
-		logrus.Fatalf("unable to start server: %s", err)
+		log.L.Fatalf("unable to start server: %s", err)
 	}
 
 	defer server.Stop()
 
-	logrus.Infof("Now run: swarmd -d . --listen-control-api ./swarmd.sock --external-ca protocol=cfssl,url=%s", server.URL)
+	log.L.Infof("Now run: swarmd -d . --listen-control-api ./swarmd.sock --external-ca protocol=cfssl,url=%s", server.URL)
 
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -40,7 +40,7 @@ var (
 		Short:        "Run a swarm control process",
 		SilenceUsage: true,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			logrus.SetOutput(os.Stderr)
+			log.L.Logger.SetOutput(os.Stderr)
 			flag, err := cmd.Flags().GetString("log-level")
 			if err != nil {
 				log.L.Fatal(err)

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/moby/swarmkit/v2/manager/encryption"
 	"github.com/moby/swarmkit/v2/node"
 	"github.com/moby/swarmkit/v2/testutils"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -154,7 +153,7 @@ func (c *testCluster) AddNode(n *testNode) error {
 
 func (c *testCluster) runNode(n *testNode, nodeOrder int) error {
 	ctx := log.WithLogger(c.ctx, log.L.WithFields(
-		logrus.Fields{
+		log.Fields{
 			"testnode": nodeOrder,
 			"testname": c.ctx.Value(testnameKey),
 		},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/moby/swarmkit/v2/ca"
 	cautils "github.com/moby/swarmkit/v2/ca/testutils"
 	"github.com/moby/swarmkit/v2/identity"
+	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager"
 	"github.com/moby/swarmkit/v2/node"
 	"github.com/moby/swarmkit/v2/testutils"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,9 +41,9 @@ func printTrace() {
 		bufferLen *= 2
 	}
 	buf = buf[:stackSize]
-	logrus.Error("===========================STACK TRACE===========================")
+	log.L.Error("===========================STACK TRACE===========================")
 	fmt.Println(string(buf))
-	logrus.Error("===========================STACK TRACE END=======================")
+	log.L.Error("===========================STACK TRACE END=======================")
 }
 
 func TestMain(m *testing.M) {

--- a/log/context.go
+++ b/log/context.go
@@ -23,6 +23,9 @@ type (
 	moduleKey struct{}
 )
 
+// Fields type to pass to "WithFields".
+type Fields = map[string]any
+
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
 func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
@@ -30,7 +33,7 @@ func WithLogger(ctx context.Context, logger *logrus.Entry) context.Context {
 }
 
 // WithFields returns a new context with added fields to logger.
-func WithFields(ctx context.Context, fields logrus.Fields) context.Context {
+func WithFields(ctx context.Context, fields Fields) context.Context {
 	logger := ctx.Value(loggerKey{})
 
 	if logger == nil {
@@ -41,7 +44,7 @@ func WithFields(ctx context.Context, fields logrus.Fields) context.Context {
 
 // WithField is convenience wrapper around WithFields.
 func WithField(ctx context.Context, key, value string) context.Context {
-	return WithFields(ctx, logrus.Fields{key: value})
+	return WithFields(ctx, Fields{key: value})
 }
 
 // GetLogger retrieves the current logger from the context. If no logger is

--- a/manager/allocator/cnmallocator/drivers_ipam.go
+++ b/manager/allocator/cnmallocator/drivers_ipam.go
@@ -1,6 +1,7 @@
 package cnmallocator
 
 import (
+	"context"
 	"strconv"
 	"strings"
 
@@ -8,7 +9,7 @@ import (
 	builtinIpam "github.com/docker/docker/libnetwork/ipams/builtin"
 	nullIpam "github.com/docker/docker/libnetwork/ipams/null"
 	"github.com/docker/docker/libnetwork/ipamutils"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/swarmkit/v2/log"
 )
 
 func initIPAMDrivers(r ipamapi.Registerer, netConfig *NetworkConfig) error {
@@ -35,7 +36,7 @@ func initIPAMDrivers(r ipamapi.Registerer, netConfig *NetworkConfig) error {
 		return err
 	}
 	if addressPool != nil {
-		logrus.Infof("Swarm initialized global default address pool to: " + str.String())
+		log.G(context.TODO()).Infof("Swarm initialized global default address pool to: " + str.String())
 	}
 
 	for _, fn := range [](func(ipamapi.Registerer) error){

--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -261,7 +260,7 @@ vipLoop:
 		}
 		for _, nAttach := range specNetworks {
 			if nAttach.Target == eAttach.NetworkID {
-				log.L.WithFields(logrus.Fields{"service_id": s.ID, "vip": eAttach.Addr}).Debug("allocate vip")
+				log.L.WithFields(log.Fields{"service_id": s.ID, "vip": eAttach.Addr}).Debug("allocate vip")
 				if err = na.allocateVIP(eAttach); err != nil {
 					return err
 				}

--- a/manager/controlapi/config.go
+++ b/manager/controlapi/config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/moby/swarmkit/v2/identity"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/state/store"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -80,7 +79,7 @@ func (s *Server) UpdateConfig(ctx context.Context, request *api.UpdateConfigRequ
 		return nil, err
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"config.ID":   request.ConfigID,
 		"config.Name": request.Spec.Annotations.Name,
 		"method":      "UpdateConfig",
@@ -166,7 +165,7 @@ func (s *Server) CreateConfig(ctx context.Context, request *api.CreateConfigRequ
 	case store.ErrNameConflict:
 		return nil, status.Errorf(codes.AlreadyExists, "config %s already exists", request.Spec.Annotations.Name)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"config.Name": request.Spec.Annotations.Name,
 			"method":      "CreateConfig",
 		}).Debugf("config created")
@@ -222,7 +221,7 @@ func (s *Server) RemoveConfig(ctx context.Context, request *api.RemoveConfigRequ
 	case store.ErrNotExist:
 		return nil, status.Errorf(codes.NotFound, "config %s not found", request.ConfigID)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"config.ID": request.ConfigID,
 			"method":    "RemoveConfig",
 		}).Debugf("config removed")

--- a/manager/controlapi/extension.go
+++ b/manager/controlapi/extension.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/swarmkit/v2/identity"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/state/store"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -37,7 +36,7 @@ func (s *Server) CreateExtension(ctx context.Context, request *api.CreateExtensi
 	case store.ErrNameConflict:
 		return nil, status.Errorf(codes.AlreadyExists, "extension %s already exists", request.Annotations.Name)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"extension.Name": request.Annotations.Name,
 			"method":         "CreateExtension",
 		}).Debugf("extension created")
@@ -121,7 +120,7 @@ func (s *Server) RemoveExtension(ctx context.Context, request *api.RemoveExtensi
 	case store.ErrNotExist:
 		return nil, status.Errorf(codes.NotFound, "extension %s not found", request.ExtensionID)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"extension.ID": request.ExtensionID,
 			"method":       "RemoveExtension",
 		}).Debugf("extension removed")

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	cautils "github.com/moby/swarmkit/v2/ca/testutils"
 	"github.com/moby/swarmkit/v2/identity"
+	"github.com/moby/swarmkit/v2/log"
 	raftutils "github.com/moby/swarmkit/v2/manager/state/raft/testutils"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/moby/swarmkit/v2/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -452,7 +452,7 @@ func TestRemoveNodes(t *testing.T) {
 
 func init() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
-	logrus.SetOutput(io.Discard)
+	log.L.Logger.SetOutput(io.Discard)
 }
 
 func getMap(t *testing.T, nodes []*api.Node) map[uint64]*api.ManagerStatus {

--- a/manager/controlapi/resource.go
+++ b/manager/controlapi/resource.go
@@ -3,7 +3,6 @@ package controlapi
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -50,7 +49,7 @@ func (s *Server) CreateResource(ctx context.Context, request *api.CreateResource
 			r.Annotations.Name,
 		)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"resource.Name": r.Annotations.Name,
 			"method":        "CreateResource",
 		}).Debugf("resource created")

--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -10,7 +10,6 @@ import (
 	"github.com/moby/swarmkit/v2/identity"
 	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/state/store"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -78,7 +77,7 @@ func (s *Server) UpdateSecret(ctx context.Context, request *api.UpdateSecretRequ
 		return nil, err
 	}
 
-	log.G(ctx).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(log.Fields{
 		"secret.ID":   request.SecretID,
 		"secret.Name": request.Spec.Annotations.Name,
 		"method":      "UpdateSecret",
@@ -174,7 +173,7 @@ func (s *Server) CreateSecret(ctx context.Context, request *api.CreateSecretRequ
 		return nil, status.Errorf(codes.AlreadyExists, "secret %s already exists", request.Spec.Annotations.Name)
 	case nil:
 		secret.Spec.Data = nil // clean the actual secret data so it's never returned
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"secret.Name": request.Spec.Annotations.Name,
 			"method":      "CreateSecret",
 		}).Debugf("secret created")
@@ -230,7 +229,7 @@ func (s *Server) RemoveSecret(ctx context.Context, request *api.RemoveSecretRequ
 	case store.ErrNotExist:
 		return nil, status.Errorf(codes.NotFound, "secret %s not found", request.SecretID)
 	case nil:
-		log.G(ctx).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"secret.ID": request.SecretID,
 			"method":    "RemoveSecret",
 		}).Debugf("secret removed")

--- a/manager/csi/csi_suite_test.go
+++ b/manager/csi/csi_suite_test.go
@@ -3,10 +3,9 @@ package csi
 import (
 	"testing"
 
+	"github.com/moby/swarmkit/v2/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
 )
 
 func TestVolumes(t *testing.T) {
@@ -15,5 +14,5 @@ func TestVolumes(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logrus.SetOutput(GinkgoWriter)
+	log.L.Logger.SetOutput(GinkgoWriter)
 })

--- a/manager/csi/manager.go
+++ b/manager/csi/manager.go
@@ -7,10 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/go-events"
-	"github.com/sirupsen/logrus"
-
 	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/go-events"
 
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
@@ -154,7 +152,7 @@ func (vm *Manager) run(pctx context.Context) {
 // processVolumes encapuslates the logic for processing pending Volumes.
 func (vm *Manager) processVolume(ctx context.Context, id string, attempt uint) {
 	// set up log fields for a derrived context to pass to handleVolume.
-	logCtx := log.WithFields(ctx, logrus.Fields{
+	logCtx := log.WithFields(ctx, log.Fields{
 		"volume.id": id,
 		"attempt":   attempt,
 	})

--- a/manager/dispatcher/assignments.go
+++ b/manager/dispatcher/assignments.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/swarmkit/v2/api/equality"
 	"github.com/moby/swarmkit/v2/api/validation"
 	"github.com/moby/swarmkit/v2/identity"
+	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/drivers"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/sirupsen/logrus"
@@ -53,7 +54,7 @@ func assignSecret(a *assignmentSet, readTx store.ReadTx, mapKey typeAndID, t *ap
 	}
 	secret, doNotReuse, err := a.secret(readTx, t, mapKey.id)
 	if err != nil {
-		a.log.WithFields(logrus.Fields{
+		a.log.WithFields(log.Fields{
 			"resource.type": "secret",
 			"secret.id":     mapKey.id,
 			"error":         err,
@@ -89,7 +90,7 @@ func assignConfig(a *assignmentSet, readTx store.ReadTx, mapKey typeAndID) {
 	a.tasksUsingDependency[mapKey] = make(map[string]struct{})
 	config := store.GetConfig(readTx, mapKey.id)
 	if config == nil {
-		a.log.WithFields(logrus.Fields{
+		a.log.WithFields(log.Fields{
 			"resource.type": "config",
 			"config.id":     mapKey.id,
 		}).Debug("config not found")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -49,7 +49,6 @@ import (
 	"github.com/moby/swarmkit/v2/remotes"
 	"github.com/moby/swarmkit/v2/xnet"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -736,7 +735,7 @@ func (m *Manager) Stop(ctx context.Context, clearData bool) {
 func (m *Manager) updateKEK(ctx context.Context, cluster *api.Cluster) error {
 	securityConfig := m.config.SecurityConfig
 	nodeID := m.config.SecurityConfig.ClientTLSCreds.NodeID()
-	logger := log.G(ctx).WithFields(logrus.Fields{
+	logger := log.G(ctx).WithFields(log.Fields{
 		"node.id":   nodeID,
 		"node.role": ca.ManagerRole,
 	})
@@ -899,11 +898,10 @@ func (m *Manager) serveListener(ctx context.Context, lCh <-chan net.Listener) {
 	case <-ctx.Done():
 		return
 	}
-	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(
-		logrus.Fields{
-			"proto": l.Addr().Network(),
-			"addr":  l.Addr().String(),
-		}))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
+		"proto": l.Addr().Network(),
+		"addr":  l.Addr().String(),
+	}))
 	if _, ok := l.(*net.TCPListener); !ok {
 		log.G(ctx).Info("Listening for local connections")
 		// we need to disallow double closes because UnixListener.Close

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moby/swarmkit/v2/log"
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/moby/swarmkit/v2/api"
@@ -17,7 +18,6 @@ import (
 	"github.com/moby/swarmkit/v2/manager/state/raft/membership"
 	raftutils "github.com/moby/swarmkit/v2/manager/state/raft/testutils"
 	"github.com/moby/swarmkit/v2/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/raft/v3/raftpb"
 )
@@ -26,7 +26,7 @@ var tc *cautils.TestCA
 
 func init() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
-	logrus.SetOutput(io.Discard)
+	log.L.Logger.SetOutput(io.Discard)
 }
 
 func TestMain(m *testing.M) {

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moby/swarmkit/v2/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -27,7 +28,6 @@ import (
 	"github.com/moby/swarmkit/v2/manager/state/raft/transport"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/moby/swarmkit/v2/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft/v3/raftpb"
@@ -42,7 +42,7 @@ const (
 func init() {
 	store.WedgeTimeout = 3 * time.Second
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
-	logrus.SetOutput(io.Discard)
+	log.L.Logger.SetOutput(io.Discard)
 }
 
 var tc *cautils.TestCA

--- a/manager/watchapi/server_test.go
+++ b/manager/watchapi/server_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/moby/swarmkit/v2/api"
 	cautils "github.com/moby/swarmkit/v2/ca/testutils"
+	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	stateutils "github.com/moby/swarmkit/v2/manager/state/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -102,5 +102,5 @@ func createNode(t *testing.T, ts *testServer, id string, role api.NodeRole, memb
 
 func init() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
-	logrus.SetOutput(io.Discard)
+	log.L.Logger.SetOutput(io.Discard)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -276,7 +276,7 @@ func configVXLANUDPPort(ctx context.Context, vxlanUDPPort uint32) {
 		log.G(ctx).WithError(err).Error("failed to configure VXLAN UDP port")
 		return
 	}
-	logrus.Infof("initialized VXLAN UDP port to %d ", vxlanUDPPort)
+	log.G(ctx).Infof("initialized VXLAN UDP port to %d ", vxlanUDPPort)
 }
 
 func (n *Node) run(ctx context.Context) (err error) {
@@ -444,7 +444,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 	go func() {
 		for certUpdate := range updates {
 			if certUpdate.Err != nil {
-				logrus.Warnf("error renewing TLS certificate: %v", certUpdate.Err)
+				log.G(ctx).Warnf("error renewing TLS certificate: %v", certUpdate.Err)
 				continue
 			}
 			// Set the new role, and notify our waiting role changing logic
@@ -862,7 +862,7 @@ func (n *Node) loadSecurityConfig(ctx context.Context, paths *ca.SecurityConfigP
 		// Attempt to load certificate from disk
 		securityConfig, cancel, err = ca.LoadSecurityConfig(ctx, rootCA, krw, n.config.ForceNewCluster)
 		if err == nil {
-			log.G(ctx).WithFields(logrus.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"node.id": securityConfig.ClientTLSCreds.NodeID(),
 			}).Debugf("loaded TLS certificate")
 		} else {

--- a/watch/queue/queue.go
+++ b/watch/queue/queue.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/docker/go-events"
-	"github.com/sirupsen/logrus"
+	"github.com/moby/swarmkit/v2/log"
 )
 
 // ErrQueueFull is returned by a Write operation when that Write causes the
@@ -112,7 +112,7 @@ func (eq *LimitQueue) run() {
 			// Eventually, go-events should not use logrus at all,
 			// and should bubble up conditions like this through
 			// error values.
-			logrus.WithFields(logrus.Fields{
+			log.L.WithFields(log.Fields{
 				"event": event,
 				"sink":  eq.dst,
 			}).WithError(err).Debug("eventqueue: dropped event")

--- a/watch/queue/queue_test.go
+++ b/watch/queue/queue_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/docker/go-events"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -142,7 +141,7 @@ func TestLimitQueueWithLimit(t *testing.T) {
 	require.Equal(1, ms.Len())
 
 	// Trying to write a new event in the queue should flush it
-	logrus.Debugf("Closing queue")
+	t.Log("Closing queue")
 	err := q.Write("test event")
 	require.Error(err)
 	require.Equal(ErrQueueFull, err)


### PR DESCRIPTION
### log: define Fields type as alternative for logrus.Fields

## reduce direct imports of logrus

swap logrus types for their swarmkit/v2/logs alternatives


**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
