### PR TITLE
Implement control-plane placement templating

### DIFF
--- a/manager/dispatcher/assignments.go
+++ b/manager/dispatcher/assignments.go
@@ -2,7 +2,6 @@ package dispatcher
 
 import (
 	"fmt"
-
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/equality"
 	"github.com/moby/swarmkit/v2/api/validation"
@@ -267,6 +266,7 @@ func (a *assignmentSet) addOrUpdateTask(readTx store.ReadTx, t *api.Task) bool {
 		// agent even if nothing else has changed.
 		if equality.TasksEqualStable(oldTask, t) && t.Status.State > api.TaskStateAssigned {
 			// this update should not trigger a task change for the agent
+
 			a.tasksMap[t.ID] = t
 			// If this task got updated to a final state, let's release
 			// the dependencies that are being used by the task

--- a/manager/orchestrator/jobs/replicated/reconciler.go
+++ b/manager/orchestrator/jobs/replicated/reconciler.go
@@ -3,6 +3,7 @@ package replicated
 import (
 	"context"
 	"fmt"
+	"github.com/moby/swarmkit/v2/template"
 
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/manager/orchestrator"
@@ -216,6 +217,13 @@ func (r *Reconciler) ReconcileService(id string) error {
 				}
 
 				task := orchestrator.NewTask(cluster, service, slot, "")
+
+				newSpec, err := template.ExpandTaskSpec(task)
+				if err != nil {
+					return err
+				}
+				task.Spec = *newSpec
+
 				// when we create the task, we also need to set the
 				// JobIteration.
 				task.JobIteration = &api.Version{Index: jobVersion}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
First pass on implementing templating of tasks for placement purposes. When combined with multiple nodes nodes labeled like `srv=1`, `srv=2`, allows for pinning of individual instances to nodes like so:
```
services:
  srv:
    deploy:
      replicas: 2
      placement:
        constraints:
          - node.labels.srv=={{Task.Slot}}
```

**- How I did it**
Re-uses the most of the existing templating code, not sure about where to template the task struct though.

**- How to test it**
Actually no idea. Open to suggestions how to make this production-level code instead of an experiment.

**- Description for the changelog**
Added support for partial templates in placement constraints.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
