### PR TITLE
agent,manager,node: define our own plugin ifaces

### DIFF
--- a/agent/csi/plugin/manager_test.go
+++ b/agent/csi/plugin/manager_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Manager", func() {
 
 	BeforeEach(func() {
 		pg = &testutils.FakePluginGetter{
-			Plugins: map[string]*testutils.FakeCompatPlugin{},
+			Plugins: map[string]*testutils.FakePlugin{},
 		}
 
 		pm = &pluginManager{
@@ -27,21 +27,21 @@ var _ = Describe("Manager", func() {
 			pg:                pg,
 		}
 
-		pg.Plugins["plug1"] = &testutils.FakeCompatPlugin{
+		pg.Plugins["plug1"] = &testutils.FakePlugin{
 			PluginName: "plug1",
 			PluginAddr: &net.UnixAddr{
 				Net:  "unix",
 				Name: "",
 			},
 		}
-		pg.Plugins["plug2"] = &testutils.FakeCompatPlugin{
+		pg.Plugins["plug2"] = &testutils.FakePlugin{
 			PluginName: "plug2",
 			PluginAddr: &net.UnixAddr{
 				Net:  "unix",
 				Name: "fail",
 			},
 		}
-		pg.Plugins["plug3"] = &testutils.FakeCompatPlugin{
+		pg.Plugins["plug3"] = &testutils.FakePlugin{
 			PluginName: "plug3",
 			PluginAddr: &net.UnixAddr{
 				Net:  "unix",

--- a/agent/csi/plugin/plugin.go
+++ b/agent/csi/plugin/plugin.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/internal/csi/capability"
 	"github.com/moby/swarmkit/v2/log"
+	"github.com/moby/swarmkit/v2/node/plugin"
 )
 
 // SecretGetter is a reimplementation of the exec.SecretGetter interface in the
@@ -88,17 +88,17 @@ const (
 	TargetPublishPath string = "/data/published"
 )
 
-func NewNodePlugin(name string, pc plugingetter.CompatPlugin, pa plugingetter.PluginAddr, secrets SecretGetter) NodePlugin {
-	return newNodePlugin(name, pc, pa, secrets)
+func NewNodePlugin(name string, p plugin.AddrPlugin, secrets SecretGetter) NodePlugin {
+	return newNodePlugin(name, p, secrets)
 }
 
 // newNodePlugin returns a raw nodePlugin object, not behind an interface. this
 // is useful for testing.
-func newNodePlugin(name string, pc plugingetter.CompatPlugin, pa plugingetter.PluginAddr, secrets SecretGetter) *nodePlugin {
+func newNodePlugin(name string, p plugin.AddrPlugin, secrets SecretGetter) *nodePlugin {
 	return &nodePlugin{
 		name:      name,
-		socket:    fmt.Sprintf("%s://%s", pa.Addr().Network(), pa.Addr().String()),
-		scopePath: pc.ScopedPath,
+		socket:    fmt.Sprintf("%s://%s", p.Addr().Network(), p.Addr().String()),
+		scopePath: p.ScopedPath,
 		secrets:   secrets,
 		volumeMap: map[string]*volumePublishStatus{},
 	}

--- a/agent/csi/plugin/plugin_fake_test.go
+++ b/agent/csi/plugin/plugin_fake_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/pkg/plugingetter"
-
 	"github.com/moby/swarmkit/v2/api"
+	mobyplugin "github.com/moby/swarmkit/v2/node/plugin"
 )
 
 // plugin_fake_test.go contains code for faking node plugins in the context of
@@ -20,7 +19,7 @@ type fakeNodePlugin struct {
 
 // newFakeNodePlugin has the same signature as NewNodePlugin, allowing it to be
 // substituted in testing.
-func newFakeNodePlugin(name string, pc plugingetter.CompatPlugin, pa plugingetter.PluginAddr, secrets SecretGetter) NodePlugin {
+func newFakeNodePlugin(name string, pa mobyplugin.AddrPlugin, secrets SecretGetter) NodePlugin {
 	return &fakeNodePlugin{
 		name:   name,
 		socket: pa.Addr().String(),

--- a/agent/csi/plugin/plugin_test.go
+++ b/agent/csi/plugin/plugin_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 func newVolumeClient(name string, nodeID string) *nodePlugin {
-	p := &testutils.FakeCompatPlugin{
+	p := &testutils.FakePlugin{
 		PluginName: name,
 		PluginAddr: &net.UnixAddr{},
 	}
-	n := newNodePlugin(name, p, p, nil)
+	n := newNodePlugin(name, p, nil)
 	n.staging = true
 
 	fakeNodeClient := newFakeNodeClient(true, nodeID)

--- a/agent/csi/volumes.go
+++ b/agent/csi/volumes.go
@@ -6,12 +6,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/pkg/plugingetter"
-
 	"github.com/moby/swarmkit/v2/agent/csi/plugin"
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
+	mobyplugin "github.com/moby/swarmkit/v2/node/plugin"
 	"github.com/moby/swarmkit/v2/volumequeue"
 )
 
@@ -46,7 +45,7 @@ type volumes struct {
 }
 
 // NewManager returns a place to store volumes.
-func NewManager(pg plugingetter.PluginGetter, secrets exec.SecretGetter) exec.VolumesManager {
+func NewManager(pg mobyplugin.Getter, secrets exec.SecretGetter) exec.VolumesManager {
 	r := &volumes{
 		volumes:        map[string]volumeState{},
 		plugins:        plugin.NewManager(pg, secrets),

--- a/agent/dependency.go
+++ b/agent/dependency.go
@@ -1,13 +1,12 @@
 package agent
 
 import (
-	"github.com/docker/docker/pkg/plugingetter"
-
 	"github.com/moby/swarmkit/v2/agent/configs"
 	"github.com/moby/swarmkit/v2/agent/csi"
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/agent/secrets"
 	"github.com/moby/swarmkit/v2/api"
+	"github.com/moby/swarmkit/v2/node/plugin"
 )
 
 type dependencyManager struct {
@@ -18,7 +17,7 @@ type dependencyManager struct {
 
 // NewDependencyManager creates a dependency manager object that wraps
 // objects which provide access to various dependency types.
-func NewDependencyManager(pg plugingetter.PluginGetter) exec.DependencyManager {
+func NewDependencyManager(pg plugin.Getter) exec.DependencyManager {
 	d := &dependencyManager{
 		secrets: secrets.NewManager(),
 		configs: configs.NewManager(),

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -42,7 +42,7 @@ func TestWorkerAssign(t *testing.T) {
 	defer cleanup()
 
 	pg := &testutils.FakePluginGetter{
-		Plugins: map[string]*testutils.FakeCompatPlugin{
+		Plugins: map[string]*testutils.FakePlugin{
 			"plugin-1": {
 				PluginName: "plugin-1",
 				PluginAddr: &net.UnixAddr{},
@@ -268,7 +268,7 @@ func TestWorkerWait(t *testing.T) {
 	ctx := context.Background()
 
 	pg := &testutils.FakePluginGetter{
-		Plugins: map[string]*testutils.FakeCompatPlugin{
+		Plugins: map[string]*testutils.FakePlugin{
 			"plugin-1": {
 				PluginName: "plugin-1",
 				PluginAddr: &net.UnixAddr{},
@@ -416,7 +416,7 @@ func TestWorkerUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	pg := &testutils.FakePluginGetter{
-		Plugins: map[string]*testutils.FakeCompatPlugin{
+		Plugins: map[string]*testutils.FakePlugin{
 			"plugin-1": {
 				PluginName: "plugin-1",
 				PluginAddr: &net.UnixAddr{},

--- a/manager/csi/fakes_test.go
+++ b/manager/csi/fakes_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/grpc"
 
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
+	mobyplugin "github.com/moby/swarmkit/v2/node/plugin"
 )
 
 const (
@@ -203,11 +203,11 @@ type fakePluginMaker struct {
 	plugins map[string]*fakePlugin
 }
 
-func (fpm *fakePluginMaker) newFakePlugin(pc plugingetter.CompatPlugin, pa plugingetter.PluginAddr, provider SecretProvider) Plugin {
+func (fpm *fakePluginMaker) newFakePlugin(pa mobyplugin.AddrPlugin, provider SecretProvider) Plugin {
 	fpm.Lock()
 	defer fpm.Unlock()
 	p := &fakePlugin{
-		name:               pc.Name(),
+		name:               pa.Name(),
 		socket:             pa.Addr().String(),
 		swarmToCSI:         map[string]string{},
 		volumesCreated:     map[string]*api.Volume{},
@@ -216,7 +216,7 @@ func (fpm *fakePluginMaker) newFakePlugin(pc plugingetter.CompatPlugin, pa plugi
 		volumesUnpublished: map[string][]string{},
 		removedIDs:         map[string]struct{}{},
 	}
-	fpm.plugins[pc.Name()] = p
+	fpm.plugins[pa.Name()] = p
 	return p
 }
 

--- a/manager/csi/manager_test.go
+++ b/manager/csi/manager_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Manager", func() {
 			plugins: map[string]*fakePlugin{},
 		}
 		pluginGetter = &testutils.FakePluginGetter{
-			Plugins: map[string]*testutils.FakeCompatPlugin{},
+			Plugins: map[string]*testutils.FakePlugin{},
 		}
 
 		s = store.NewMemoryStore(nil)
@@ -108,14 +108,14 @@ var _ = Describe("Manager", func() {
 
 	When("starting up", func() {
 		BeforeEach(func() {
-			pluginGetter.Plugins["newPlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["newPlugin"] = &testutils.FakePlugin{
 				PluginName: "newPlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
 					Name: "unix:///whatever.sock",
 				},
 			}
-			pluginGetter.Plugins["differentPlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["differentPlugin"] = &testutils.FakePlugin{
 				PluginName: "differentPlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
@@ -233,14 +233,14 @@ var _ = Describe("Manager", func() {
 
 	When("a volume is created", func() {
 		BeforeEach(func() {
-			pluginGetter.Plugins["somePlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["somePlugin"] = &testutils.FakePlugin{
 				PluginName: "somePlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
 					Name: "unix:///whatever.sock",
 				},
 			}
-			pluginGetter.Plugins["someOtherPlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["someOtherPlugin"] = &testutils.FakePlugin{
 				PluginName: "someOtherPlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
@@ -297,14 +297,14 @@ var _ = Describe("Manager", func() {
 
 	Describe("managing node inventory", func() {
 		BeforeEach(func() {
-			pluginGetter.Plugins["newPlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["newPlugin"] = &testutils.FakePlugin{
 				PluginName: "newPlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
 					Name: "unix:///whatever.sock",
 				},
 			}
-			pluginGetter.Plugins["differentPlugin"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["differentPlugin"] = &testutils.FakePlugin{
 				PluginName: "differentPlugin",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
@@ -469,7 +469,7 @@ var _ = Describe("Manager", func() {
 			v1 *api.Volume
 		)
 		BeforeEach(func() {
-			pluginGetter.Plugins["plug1"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["plug1"] = &testutils.FakePlugin{
 				PluginName: "plug1",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",
@@ -666,7 +666,7 @@ var _ = Describe("Manager", func() {
 
 	Describe("removing a Volume", func() {
 		BeforeEach(func() {
-			pluginGetter.Plugins["plug"] = &testutils.FakeCompatPlugin{
+			pluginGetter.Plugins["plug"] = &testutils.FakePlugin{
 				PluginName: "plug",
 				PluginAddr: &net.UnixAddr{
 					Net:  "unix",

--- a/manager/csi/plugin.go
+++ b/manager/csi/plugin.go
@@ -10,10 +10,10 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/internal/csi/capability"
 	"github.com/moby/swarmkit/v2/log"
+	mobyplugin "github.com/moby/swarmkit/v2/node/plugin"
 )
 
 // Plugin is the interface for a CSI controller plugin.
@@ -74,12 +74,12 @@ type plugin struct {
 // the same object. By taking both parts here, we can push off the work of
 // assuring that the given plugin implements the PluginAddr interface without
 // having to typecast in this constructor.
-func NewPlugin(pc plugingetter.CompatPlugin, pa plugingetter.PluginAddr, provider SecretProvider) Plugin {
+func NewPlugin(p mobyplugin.AddrPlugin, provider SecretProvider) Plugin {
 	return &plugin{
-		name: pc.Name(),
+		name: p.Name(),
 		// TODO(dperny): verify that we do not need to include the Network()
 		// portion of the Addr.
-		socket:     fmt.Sprintf("%s://%s", pa.Addr().Network(), pa.Addr().String()),
+		socket:     fmt.Sprintf("%s://%s", p.Addr().Network(), p.Addr().String()),
 		provider:   provider,
 		swarmToCSI: map[string]string{},
 		csiToSwarm: map[string]string{},

--- a/manager/drivers/provider.go
+++ b/manager/drivers/provider.go
@@ -3,17 +3,17 @@ package drivers
 import (
 	"fmt"
 
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
+	"github.com/moby/swarmkit/v2/node/plugin"
 )
 
 // DriverProvider provides external drivers
 type DriverProvider struct {
-	pluginGetter plugingetter.PluginGetter
+	pluginGetter plugin.Getter
 }
 
 // New returns a new driver provider
-func New(pluginGetter plugingetter.PluginGetter) *DriverProvider {
+func New(pluginGetter plugin.Getter) *DriverProvider {
 	return &DriverProvider{pluginGetter: pluginGetter}
 }
 
@@ -26,7 +26,7 @@ func (m *DriverProvider) NewSecretDriver(driver *api.Driver) (*SecretDriver, err
 		return nil, fmt.Errorf("driver specification is nil")
 	}
 	// Search for the specified plugin
-	plugin, err := m.pluginGetter.Get(driver.Name, SecretsProviderCapability, plugingetter.Lookup)
+	plugin, err := m.pluginGetter.Get(driver.Name, SecretsProviderCapability)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/drivers/secrets.go
+++ b/manager/drivers/secrets.go
@@ -3,9 +3,9 @@ package drivers
 import (
 	"fmt"
 
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/naming"
+	"github.com/moby/swarmkit/v2/node/plugin"
 )
 
 const (
@@ -18,11 +18,11 @@ const (
 
 // SecretDriver provides secrets from different stores
 type SecretDriver struct {
-	plugin plugingetter.CompatPlugin
+	plugin plugin.Plugin
 }
 
 // NewSecretDriver creates a new driver that provides third party secrets
-func NewSecretDriver(plugin plugingetter.CompatPlugin) *SecretDriver {
+func NewSecretDriver(plugin plugin.Plugin) *SecretDriver {
 	return &SecretDriver{plugin: plugin}
 }
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-events"
 	gmetrics "github.com/docker/go-metrics"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -45,6 +44,7 @@ import (
 	"github.com/moby/swarmkit/v2/manager/state/raft/transport"
 	"github.com/moby/swarmkit/v2/manager/state/store"
 	"github.com/moby/swarmkit/v2/manager/watchapi"
+	"github.com/moby/swarmkit/v2/node/plugin"
 	"github.com/moby/swarmkit/v2/remotes"
 	"github.com/moby/swarmkit/v2/xnet"
 	"github.com/pkg/errors"
@@ -123,7 +123,7 @@ type Config struct {
 	Availability api.NodeSpec_Availability
 
 	// PluginGetter provides access to docker's plugin inventory.
-	PluginGetter plugingetter.PluginGetter
+	PluginGetter plugin.Getter
 
 	// FIPS is a boolean stating whether the node is FIPS enabled - if this is the
 	// first node in the cluster, this setting is used to set the cluster-wide mandatory

--- a/node/node.go
+++ b/node/node.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-metrics"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/moby/swarmkit/v2/agent"
@@ -30,6 +29,7 @@ import (
 	"github.com/moby/swarmkit/v2/manager"
 	"github.com/moby/swarmkit/v2/manager/allocator/networkallocator"
 	"github.com/moby/swarmkit/v2/manager/encryption"
+	"github.com/moby/swarmkit/v2/node/plugin"
 	"github.com/moby/swarmkit/v2/remotes"
 	"github.com/moby/swarmkit/v2/xnet"
 	"github.com/pkg/errors"
@@ -134,7 +134,7 @@ type Config struct {
 	Availability api.NodeSpec_Availability
 
 	// PluginGetter provides access to docker's plugin inventory.
-	PluginGetter plugingetter.PluginGetter
+	PluginGetter plugin.Getter
 
 	// FIPS is a boolean stating whether the node is FIPS enabled
 	FIPS bool

--- a/node/plugin/pluginapi.go
+++ b/node/plugin/pluginapi.go
@@ -1,0 +1,23 @@
+package plugin
+
+import "net"
+
+type Plugin interface {
+	Name() string
+	ScopedPath(string) string
+	Client() Client
+}
+
+type AddrPlugin interface {
+	Plugin
+	Addr() net.Addr
+}
+
+type Client interface {
+	Call(method string, args, ret interface{}) error
+}
+
+type Getter interface {
+	Get(name, capability string) (Plugin, error)
+	GetAllManagedPluginsByCap(capability string) []Plugin
+}

--- a/testutils/fake_plugingetter.go
+++ b/testutils/fake_plugingetter.go
@@ -3,20 +3,20 @@ package testutils
 import (
 	"fmt"
 	"net"
-	"time"
 
-	"github.com/docker/docker/pkg/plugingetter"
-	"github.com/docker/docker/pkg/plugins"
+	"github.com/moby/swarmkit/v2/node/plugin"
 )
 
 const DockerCSIPluginNodeCap = "csinode"
 const DockerCSIPluginControllerCap = "csicontroller"
 
 type FakePluginGetter struct {
-	Plugins map[string]*FakeCompatPlugin
+	Plugins map[string]*FakePlugin
 }
 
-func (f *FakePluginGetter) Get(name, capability string, _ int) (plugingetter.CompatPlugin, error) {
+var _ plugin.Getter = &FakePluginGetter{}
+
+func (f *FakePluginGetter) Get(name, capability string) (plugin.Plugin, error) {
 	if capability != DockerCSIPluginNodeCap && capability != DockerCSIPluginControllerCap {
 		return nil, fmt.Errorf(
 			"requested plugin with %s cap, but should only ever request %s or %s",
@@ -30,63 +30,43 @@ func (f *FakePluginGetter) Get(name, capability string, _ int) (plugingetter.Com
 	return nil, fmt.Errorf("plugin %s not found", name)
 }
 
-// GetAllByCap is not needed in the fake and is unimplemented
-func (f *FakePluginGetter) GetAllByCap(_ string) ([]plugingetter.CompatPlugin, error) {
-	return nil, nil
-}
-
 // GetAllManagedPluginsByCap returns all of the fake's plugins. If capability
 // is anything other than DockerCSIPluginCap, it returns nothing.
-func (f *FakePluginGetter) GetAllManagedPluginsByCap(capability string) []plugingetter.CompatPlugin {
+func (f *FakePluginGetter) GetAllManagedPluginsByCap(capability string) []plugin.Plugin {
 	if capability != DockerCSIPluginNodeCap && capability != DockerCSIPluginControllerCap {
 		return nil
 	}
 
-	allPlugins := make([]plugingetter.CompatPlugin, 0, len(f.Plugins))
+	allPlugins := make([]plugin.Plugin, 0, len(f.Plugins))
 	for _, plug := range f.Plugins {
 		allPlugins = append(allPlugins, plug)
 	}
 	return allPlugins
 }
 
-// Handle is not needed in the fake, so is unimplemented.
-func (f *FakePluginGetter) Handle(_ string, _ func(string, *plugins.Client)) {}
-
-// fakeCompatPlugin is a fake implementing the plugingetter.CompatPlugin and
-// plugingetter.PluginAddr interfaces
-type FakeCompatPlugin struct {
+type FakePlugin struct {
 	PluginName string
 	PluginAddr net.Addr
 	Scope      string
 }
 
-func (f *FakeCompatPlugin) Name() string {
+var _ plugin.AddrPlugin = &FakePlugin{}
+
+func (f *FakePlugin) Name() string {
 	return f.PluginName
 }
 
-func (f *FakeCompatPlugin) ScopedPath(path string) string {
+func (f *FakePlugin) ScopedPath(path string) string {
 	if f.Scope != "" {
 		return fmt.Sprintf("%s/%s", f.Scope, path)
 	}
 	return path
 }
 
-func (f *FakeCompatPlugin) IsV1() bool {
-	return false
-}
-
-func (f *FakeCompatPlugin) Client() *plugins.Client {
+func (f *FakePlugin) Client() plugin.Client {
 	return nil
 }
 
-func (f *FakeCompatPlugin) Addr() net.Addr {
+func (f *FakePlugin) Addr() net.Addr {
 	return f.PluginAddr
-}
-
-func (f *FakeCompatPlugin) Timeout() time.Duration {
-	return time.Second
-}
-
-func (f *FakeCompatPlugin) Protocol() string {
-	return ""
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow Moby plugins to be used without Swarmkit having to import github.com/docker/docker packages by defining our own interfaces which cover the subset of functionality we use. Adapters will have to be written on the Moby side as their API contains methods which return concrete struct types, [but they only need to be trivial wrappers as their `*plugins.Client` satisfies our `plugin.Client` interface.](https://github.com/moby/moby/blob/6fe7928c8c9b29bcd2d0232c356e76134656901f/daemon/cluster/convert/pluginadapter.go)

The manager/allocator/cnmallocator package was not modified and continues to import the plugin types defined in github.com/docker/docker. It also imports many other packages under github.com/docker/docker. The package will be moved out of Swarmkit into github.com/docker/docker as the final step of dropping our dependency on docker/docker.

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- The type of `(node.Config).PluginGetter` is now an interface defined in the swarmkit module which `"github.com/docker/docker/plugin".Store` does not satisfy. Adapter types may be required.