### PR TITLE
CSI node plugin fix for unstaging volumes

### DIFF
--- a/agent/csi/plugin/plugin.go
+++ b/agent/csi/plugin/plugin.go
@@ -263,11 +263,8 @@ func (np *nodePlugin) NodeUnstageVolume(ctx context.Context, req *api.VolumeAssi
 
 	// we must unpublish before we unstage. verify here that the volume is not
 	// published.
-	if v, ok := np.volumeMap[req.ID]; ok {
-		if v.isPublished {
-			return status.Errorf(codes.FailedPrecondition, "Volume %s is not unpublished", req.ID)
-		}
-		return nil
+	if v, ok := np.volumeMap[req.ID]; ok && v.isPublished {
+		return status.Errorf(codes.FailedPrecondition, "Volume %s is not unpublished", req.ID)
 	}
 
 	_, err = c.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{


### PR DESCRIPTION
**- What I did**
While running a CSI volume plugin that supports staging, I created a new swarm service that initiated an attempt to unpublish a cluster volume. The node agent calls `NodeUnpublishVolume` which returns no errors then `NodeUnstageVolume` which also returns no errors. However, there was no call to the underlying plugin driver for `NodeUnstageVolume`.

**- How I did it**
Fixed the unpublish check to only return in the failing condition that the volume was not unpublished.

**- How to test it**
Create a cluster volume using CSI volume plugin then trigger a publish and unpublish by creating a swarm service and restarting the service.

**- Description for the changelog**