### PR TITLE
fix CSI plugin load issue (plugin does not implement PluginAddr)

### DIFF
--- a/manager/csi/fakes_test.go
+++ b/manager/csi/fakes_test.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
@@ -209,6 +210,7 @@ func (fpm *fakePluginMaker) newFakePlugin(pa mobyplugin.AddrPlugin, provider Sec
 	p := &fakePlugin{
 		name:               pa.Name(),
 		socket:             pa.Addr().String(),
+		addr:               pa.Addr(),
 		swarmToCSI:         map[string]string{},
 		volumesCreated:     map[string]*api.Volume{},
 		volumesDeleted:     []string{},
@@ -223,6 +225,7 @@ func (fpm *fakePluginMaker) newFakePlugin(pa mobyplugin.AddrPlugin, provider Sec
 type fakePlugin struct {
 	name       string
 	socket     string
+	addr       net.Addr
 	swarmToCSI map[string]string
 	// removedIDs is a set of node IDs for which RemoveNode has been called.
 	removedIDs map[string]struct{}
@@ -286,4 +289,8 @@ func (f *fakePlugin) AddNode(swarmID, csiID string) {
 
 func (f *fakePlugin) RemoveNode(swarmID string) {
 	f.removedIDs[swarmID] = struct{}{}
+}
+
+func (f *fakePlugin) Addr() net.Addr {
+	return f.addr
 }


### PR DESCRIPTION
CSI plugin does not implement plugin.PluginAddr interface so plugin manager will not load any CSI plugins at all. (see agent/csi/plugin/csi/manager.go:111)

Basicly preventing load of any CSI plugin with following error message volume creation failed: plugin for driver "seaweedfs" does not implement PluginAddr

fixes https://github.com/hetznercloud/csi-driver/issues/680
https://github.com/moby/moby/issues/48133
