### PR TITLE
Remove weak TLS cipher suites

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"math/rand"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -59,6 +60,17 @@ var (
 	// digest)
 	errInvalidJoinToken = errors.New("invalid join token")
 )
+
+// strongTLSCiphers defines a secure, modern set of TLS cipher suites
+// with known weak algorithms removed.
+var strongTLSCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
 
 // SecurityConfig is used to represent a node's security configuration. It includes information about
 // the RootCA and ServerTLSCreds/ClientTLSCreds transport authenticators to be used for MTLS
@@ -649,6 +661,7 @@ func NewServerTLSConfig(certs []tls.Certificate, rootCAPool *x509.CertPool) (*tl
 		RootCAs:                  rootCAPool,
 		ClientCAs:                rootCAPool,
 		PreferServerCipherSuites: true,
+		CipherSuites:             slices.Clone(strongTLSCiphers),
 		MinVersion:               tls.VersionTLS12,
 		NextProtos:               alpnProtoStr,
 	}, nil
@@ -665,6 +678,7 @@ func NewClientTLSConfig(certs []tls.Certificate, rootCAPool *x509.CertPool, serv
 		ServerName:   serverName,
 		Certificates: certs,
 		RootCAs:      rootCAPool,
+		CipherSuites: slices.Clone(strongTLSCiphers),
 		MinVersion:   tls.VersionTLS12,
 	}, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a new `strongTLSCiphers` list defining a secure, modern set of TLS cipher suites.
- Removed weak and deprecated algorithms (_CBC_-mode ciphers) by only allowing _AES-GCM_ and _ChaCha20-Poly1305_.
- Updated both server and client TLS configurations to use `strongTLSCiphers`.

**- How I did it**
- Created the `strongTLSCiphers` variable containing only secure ciphers.
- Configured `NewServerTLSConfig` and `NewClientTLSConfig` to use a clone of `strongTLSCiphers` via `CipherSuites`.

**- How to test it**

- Before enforcing strong TLS ciphers, weak _CBC_-mode ciphers were allowed, for example:
  - https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256/
  - https://ciphersuite.info/cs/TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA/
```
➜  swarmkit git:(master) ✗ nmap --script ssl-enum-ciphers -p 4242 127.0.0.1          
Starting Nmap 7.98 ( https://nmap.org/ ) at 2025-10-03 15:54 +0400
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00014s latency).

PORT     STATE SERVICE
4242/tcp open  vrml-multi-use
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     compressors: 
|       NULL
|     cipher preference: client
|   TLSv1.3: 
|     ciphers: 
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A
```
- Verify that, after applying `strongTLSCiphers`, only secure ciphers are enabled and all weak _CBC_-mode ciphers are removed:

```
➜  swarmkit git:(master) ✗ nmap --script ssl-enum-ciphers -p 4242 127.0.0.1  
Starting Nmap 7.98 ( https://nmap.org/ ) at 2025-10-03 19:24 +0400
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00014s latency).

PORT     STATE SERVICE
4242/tcp open  vrml-multi-use
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 (secp256r1) - A
|       TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 (secp256r1) - A
|     compressors: 
|       NULL
|     cipher preference: client
|   TLSv1.3: 
|     ciphers: 
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A
```

**- Description for the changelog**

Removed weak TLS cipher suites and allowed only modern, secure ciphers.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
