### PR TITLE
manager/logbroker: bound the log and subscription queues

### DIFF
--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -23,6 +23,28 @@ var (
 	errNotRunning     = errors.New("broker is not running")
 )
 
+const (
+	// subscriptionQueueLimit bounds how many subscription events may be
+	// buffered for a single ListenSubscriptions watcher.
+	//
+	// A watcher stops draining its channel whenever stream.Send blocks, which
+	// happens when the agent's gRPC stream stalls -- an unresponsive or
+	// partitioned node, for example. Without a limit, every subscription
+	// published from that point on is retained by the watcher's queue, along
+	// with its SubscriptionMessage, LogSelector, LogSubscriptionOptions and
+	// cancel context, even after the subscription has been unregistered.
+	//
+	// Tearing the watcher down instead is recoverable: ListenSubscriptions
+	// returns an error, the agent reconnects, and watchSubscriptions replays
+	// the currently registered subscriptions for that node.
+	subscriptionQueueLimit = 1000
+
+	// logQueueLimit bounds how many log messages may be buffered for a single
+	// SubscribeLogs client. A client that cannot keep up has its log stream
+	// terminated rather than growing the manager's heap without bound.
+	logQueueLimit = 10000
+)
+
 type logMessage struct {
 	*api.PublishLogsMessage
 	completed bool
@@ -65,8 +87,12 @@ func (lb *LogBroker) Start(ctx context.Context) error {
 	}
 
 	lb.pctx, lb.cancelAll = context.WithCancel(ctx)
-	lb.logQueue = watch.NewQueue()
-	lb.subscriptionQueue = watch.NewQueue()
+	// Both queues are bounded and close their output channel on teardown, so a
+	// consumer that stops draining is disconnected instead of being buffered
+	// without bound. Callers must handle a closed channel; see SubscribeLogs
+	// and ListenSubscriptions.
+	lb.logQueue = watch.NewQueue(watch.WithLimit(logQueueLimit), watch.WithCloseOutChan())
+	lb.subscriptionQueue = watch.NewQueue(watch.WithLimit(subscriptionQueueLimit), watch.WithCloseOutChan())
 	lb.registeredSubscriptions = make(map[string]*subscription)
 	lb.subscriptionsByNode = make(map[string]map[*subscription]struct{})
 	return nil
@@ -257,7 +283,13 @@ func (lb *LogBroker) SubscribeLogs(request *api.SubscribeLogsRequest, stream api
 			return ctx.Err()
 		case <-pctx.Done():
 			return pctx.Err()
-		case event := <-publishCh:
+		case event, ok := <-publishCh:
+			if !ok {
+				// The queue tore the watcher down because this client fell
+				// further behind than logQueueLimit.
+				logger.Error("log stream terminated: client is too far behind")
+				return status.Errorf(codes.ResourceExhausted, "log stream terminated: client is too far behind")
+			}
 			publish := event.(*logMessage)
 			if publish.completed {
 				return publish.err
@@ -349,7 +381,15 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 	// Send down new subscriptions.
 	for {
 		select {
-		case v := <-subscriptionCh:
+		case v, ok := <-subscriptionCh:
+			if !ok {
+				// The queue tore the watcher down because this node fell
+				// further behind than subscriptionQueueLimit. Returning an
+				// error lets the agent reconnect, at which point
+				// watchSubscriptions replays the current subscriptions.
+				logger.Error("subscription stream terminated: node is too far behind")
+				return status.Errorf(codes.ResourceExhausted, "subscription stream terminated: node is too far behind")
+			}
 			sub := v.(*subscription)
 
 			if sub.Closed() {

--- a/manager/logbroker/broker_queue_test.go
+++ b/manager/logbroker/broker_queue_test.go
@@ -1,0 +1,123 @@
+package logbroker
+
+import (
+	"context"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moby/swarmkit/v2/api"
+	"github.com/moby/swarmkit/v2/manager/state/store"
+	"github.com/stretchr/testify/require"
+)
+
+// subscriptionRetention drives `count` subscriptions through their full,
+// correct lifecycle (Run -> register -> unregister -> Stop) against a broker
+// whose only ListenSubscriptions watcher behaves as described by `drain`, and
+// reports how many of those subscriptions the runtime was able to reclaim
+// afterwards.
+//
+// A subscription that has been unregistered is no longer referenced by any of
+// the broker's bookkeeping maps, so a correctly behaving broker must allow it
+// to be collected regardless of what the watcher is doing.
+func subscriptionRetention(t *testing.T, count int, drain bool) (reclaimed int64) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := store.NewMemoryStore(nil)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	broker := New(s)
+	require.NoError(t, broker.Start(ctx))
+	defer broker.Stop()
+
+	const nodeID = "node-stalled"
+	broker.nodeConnected(nodeID)
+
+	// Stand in for ListenSubscriptions: it registers a watch on the
+	// subscriptionQueue and, in the failure case, stops reading from the
+	// channel. That is what happens in ListenSubscriptions when stream.Send
+	// blocks on a worker whose gRPC stream has stalled -- the loop never gets
+	// back around to `case v := <-subscriptionCh`.
+	_, subscriptionCh, cancelWatch := broker.watchSubscriptions(nodeID)
+	defer cancelWatch()
+
+	stopDraining := make(chan struct{})
+	defer close(stopDraining)
+	if drain {
+		go func() {
+			for {
+				select {
+				case <-subscriptionCh:
+				case <-stopDraining:
+					return
+				}
+			}
+		}()
+	}
+
+	var collected atomic.Int64
+	for range count {
+		sub := broker.newSubscription(
+			&api.LogSelector{NodeIDs: []string{nodeID}},
+			&api.LogSubscriptionOptions{},
+		)
+		runtime.SetFinalizer(sub, func(*subscription) { collected.Add(1) })
+
+		// Mirror SubscribeLogs exactly, including every cleanup step it
+		// performs on return.
+		sub.Run(ctx)
+		broker.registerSubscription(sub)
+		broker.unregisterSubscription(sub)
+		sub.Stop()
+	}
+
+	// Nothing in this function still references the subscriptions. Give the
+	// collector several opportunities to reclaim them and to run finalizers.
+	for range 5 {
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+	}
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+
+	return collected.Load()
+}
+
+// TestLogBrokerSubscriptionQueueBounded asserts that a ListenSubscriptions
+// watcher which stops draining its channel cannot pin an unbounded number of
+// subscriptions.
+//
+// A watcher stops draining whenever stream.Send blocks, which happens when the
+// agent's gRPC stream stalls. registerSubscription and unregisterSubscription
+// both publish the *subscription to subscriptionQueue, so an unbounded queue
+// lets a single stalled watcher retain every subscription that has passed
+// through the broker -- along with its SubscriptionMessage, LogSelector,
+// LogSubscriptionOptions and cancel context -- even though each subscription
+// was unregistered correctly.
+//
+// Because the backlog accumulates in a container/list rather than in blocked
+// goroutines, such a leak is invisible to goroutine-count based monitoring and
+// shows up only as unexplained heap growth in the manager.
+func TestLogBrokerSubscriptionQueueBounded(t *testing.T) {
+	// Push well past the limit so a bounded queue has to shed load.
+	const count = 3 * subscriptionQueueLimit
+
+	t.Run("draining watcher", func(t *testing.T) {
+		reclaimed := subscriptionRetention(t, count, true)
+		t.Logf("reclaimed %d/%d subscriptions", reclaimed, count)
+		require.EqualValues(t, count, reclaimed,
+			"a watcher that drains its channel must not pin unregistered subscriptions")
+	})
+
+	t.Run("stalled watcher", func(t *testing.T) {
+		reclaimed := subscriptionRetention(t, count, false)
+		t.Logf("reclaimed %d/%d subscriptions", reclaimed, count)
+		require.GreaterOrEqual(t, reclaimed, int64(count-subscriptionQueueLimit),
+			"a stalled watcher must not retain more than subscriptionQueueLimit subscriptions")
+	})
+}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/46068

**- What I did**

Bounded the log broker's two queues so that a consumer which stops draining can
no longer cause unbounded manager memory growth.

`LogBroker.Start` creates both queues with `watch.NewQueue()` and no options,
which yields a `LimitQueue` with `limit: 0` -- documented as "limitless".
`LimitQueue.Write` skips its size check entirely in that case:

```go
if eq.limit > 0 && uint64(eq.events.Len()) >= eq.limit {
    ...
}
eq.events.PushBack(event)
```

Each watcher's sink is an unbuffered channel (`events.NewChannel(0)` in
`watch/sinks.go`), so once a watcher stops reading, the queue keeps appending to
an unbounded `container/list` rather than applying backpressure or shedding
load.

`ListenSubscriptions` stops draining its channel whenever `stream.Send` blocks,
which happens when an agent's gRPC stream stalls -- an unresponsive or
partitioned node, for example. Both `registerSubscription` and
`unregisterSubscription` publish the `*subscription` to `subscriptionQueue`, so
a single stalled watcher pins every subscription that has passed through the
broker, along with its `SubscriptionMessage`, `LogSelector`,
`LogSubscriptionOptions` and cancel context -- even though each subscription was
unregistered correctly.

Because the backlog accumulates in a `container/list` rather than in blocked
goroutines, the growth is invisible to goroutine-count based monitoring and
surfaces only as unexplained manager heap growth.

This matches the profile in moby/moby#46068. We hit it in production: a
single-node swarm manager reached ~27 GB RSS with a normal goroutine count (320)
and normal fd count (143). A heap profile attributed 99.4% of the heap to the log
broker:

```
_Logs_SubscribeLogs_Handler                     23.33GB  (91.69% cum)
  logbroker.newSubscription (inline)             6.75GB
  logbroker.(*subscription).match.func1          4.40GB
  api.(*SubscribeLogsRequest).Unmarshal          3.83GB
  context.newCancelCtx                           2.39GB
  logbroker.(*LogBroker).ListenSubscriptions     1.73GB
  api.(*LogSubscriptionOptions).Unmarshal        1.65GB
  api.(*LogSelector).Unmarshal                   1.44GB
```

**- How I did it**

Gave both queues a limit and `WithCloseOutChan()`, so a consumer that falls too
far behind is disconnected instead of buffered without bound. Disconnecting is
recoverable: `ListenSubscriptions` returns an error, the agent reconnects, and
`watchSubscriptions` replays the currently registered subscriptions for that
node.

Both receive sites now handle a closed channel. Without that, closing the output
channel would turn the leak into a nil type-assertion panic on
`v.(*subscription)`.

**- How to test it**

```
go test ./manager/logbroker/ -run TestLogBrokerSubscriptionQueueBounded -v
```

The added test drives subscriptions through their full lifecycle
(`Run` -> `register` -> `unregister` -> `Stop`) and uses finalizers to check
whether the runtime can reclaim them. A subscription that has been unregistered
is no longer referenced by any of the broker's bookkeeping maps, so a correctly
behaving broker must allow it to be collected regardless of what the watcher is
doing.

| watcher | before | after |
|---|---|---|
| draining | 3000/3000 reclaimed | 3000/3000 reclaimed |
| stalled | **0/3000 reclaimed** | 2499/3000 reclaimed |

Retention after the change is bounded rather than zero, because the queue may
legitimately hold up to `subscriptionQueueLimit` events. Each subscription
publishes twice (register + unregister), so ~501 subscriptions are retained.
Scaling the input confirms the bound holds:

| subscriptions driven through | retained |
|---|---|
| 3,000 | 501 |
| 10,000 | 501 |
| 30,000 | 501 |

The test fails on `master` and passes with this change. Existing
`manager/logbroker`, `watch` and `watch/queue` tests pass; `go vet` and `gofmt`
are clean.

**- Description for the changelog**

Bound the swarm log broker's log and subscription queues so a stalled consumer
can no longer cause unbounded manager memory growth.

---

### Open questions

I would appreciate guidance on two points.

**1. The limit values are arbitrary.** I chose `subscriptionQueueLimit = 1000`
and `logQueueLimit = 10000` based on relative event frequency: subscription
events occur a couple of times per `docker service logs` invocation, while log
events track container output volume, so a single shared value would trip the
log queue under normal load.

That reasoning only accounts for frequency, not for per-event size. A
`PublishLogsMessage` carries a batch of log lines and can be far larger than a
`*subscription`, so 10,000 log events may well cost more memory than 1,000
subscriptions. What we actually want to bound is bytes, but `watch.Queue` only
offers a count-based limit. Happy to change these numbers, make them
configurable, or take a different approach.

**2. Tearing the watcher down may be too blunt for `logQueue`.** For
`subscriptionQueue` the consumer is an agent, and disconnecting it triggers a
reconnect that re-syncs state. For `logQueue` the consumer is a
`docker service logs` client, where falling behind on a slow link is a fairly
normal condition, and the user sees the stream terminate with
`ResourceExhausted`. `watch.WithTimeout` may be a better fit there; I kept both
queues consistent for now.

### Notes

- `watch.WithLimit` and `watch.WithTimeout` exist but are currently unused by any
  production call site; all eight `watch.NewQueue()` callers pass no options.
  Other queues may warrant the same treatment, but I have limited this change to
  the broker, where there is a reproduction.
- The reproduction is synthetic. It models a watcher that stops draining, which
  is the state a stalled `stream.Send` leaves `ListenSubscriptions` in, but it
  does not reproduce the original production trigger (a node going offline and
  returning, as also described in moby/moby#46068).
- Tested on darwin/arm64 with Go 1.25.1. The test relies on finalizers running
  after `runtime.GC()`; it was stable across 10 consecutive runs, but it would be
  worth confirming the behaviour on CI.
