### PR TITLE
manager: ListWALs: remove redundant sort, and skip directories

### DIFF
--- a/manager/state/raft/storage/walwrap.go
+++ b/manager/state/raft/storage/walwrap.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/moby/swarmkit/v2/log"
@@ -247,12 +246,12 @@ func ListWALs(dirpath string) ([]string, error) {
 
 	var wals []string
 	for _, dirent := range dirents {
-		if strings.HasSuffix(dirent.Name(), ".wal") {
-			wals = append(wals, dirent.Name())
+		if dirent.IsDir() {
+			continue
+		}
+		if name := dirent.Name(); strings.HasSuffix(name, ".wal") {
+			wals = append(wals, name)
 		}
 	}
-
-	// Sort WAL filenames in lexical order
-	sort.Sort(sort.StringSlice(wals))
 	return wals, nil
 }


### PR DESCRIPTION
os.ReadDir already returns a sorted list;

    // ReadDir reads the named directory,
    // returning all its directory entries sorted by filename.

Remove the manual sort, and while updating, also skip directories, because we're looking for files.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
