### PR TITLE
Initialize CSI client before checking publish capability

### DIFF
--- a/manager/csi/plugin.go
+++ b/manager/csi/plugin.go
@@ -208,6 +208,11 @@ func (p *plugin) DeleteVolume(ctx context.Context, v *api.Volume) error {
 // the Node with the given swarmkit ID. It returns a map, which is the
 // PublishContext for this Volume on this Node.
 func (p *plugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string) (map[string]string, error) {
+	c, err := p.Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if !p.publisher {
 		return nil, nil
 	}
@@ -218,10 +223,6 @@ func (p *plugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string
 	}
 
 	req := p.makeControllerPublishVolumeRequest(v, nodeID)
-	c, err := p.Client(ctx)
-	if err != nil {
-		return nil, err
-	}
 	resp, err := c.ControllerPublishVolume(ctx, req)
 
 	if err != nil {
@@ -234,15 +235,16 @@ func (p *plugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string
 // Volume from the Node with the given swarmkit ID. It returns an error if the
 // unpublish does not succeed
 func (p *plugin) UnpublishVolume(ctx context.Context, v *api.Volume, nodeID string) error {
+	c, err := p.Client(ctx)
+	if err != nil {
+		return err
+	}
+
 	if !p.publisher {
 		return nil
 	}
 
 	req := p.makeControllerUnpublishVolumeRequest(v, nodeID)
-	c, err := p.Client(ctx)
-	if err != nil {
-		return err
-	}
 
 	// response of the RPC intentionally left blank
 	_, err = c.ControllerUnpublishVolume(ctx, req)


### PR DESCRIPTION
## Summary

Initialize the CSI plugin client before checking whether the plugin supports `PUBLISH_UNPUBLISH_VOLUME`.

## Problem

The `publisher` field is populated during CSI client initialization, when SwarmKit calls `ControllerGetCapabilities`.

After a Swarm manager restart or leader change, a new plugin wrapper starts with:

```go
publisher = false
```

However, `PublishVolume` checks this field before calling `Client()`:

```go
if !p.publisher {
    return nil, nil
}
```

At this point, `false` may mean that the plugin has not been initialized yet, rather than that it does not support controller publish/unpublish operations.

As a result, SwarmKit can incorrectly treat volume publication as successful without calling `ControllerPublishVolume` and without receiving a publish context.

For the AWS EBS CSI driver, this produces the following failure sequence:

1. SwarmKit marks the volume as published.
2. The EBS volume remains `available` because no attach request was made.
3. The node receives an empty publish context.
4. `NodeStageVolume` fails with:

```text
rpc error: code = InvalidArgument desc = Device path not provided
```

The volume then appears as `in use` in Docker, while it is not attached in AWS.

## Fix

Call `Client()` before checking `p.publisher`:

```go
c, err := p.Client(ctx)
if err != nil {
    return nil, err
}

if !p.publisher {
    return nil, nil
}
```

This ensures that plugin capabilities are loaded before SwarmKit decides whether controller-side publish operations are supported.

## Reproduction

1. Create an AWS EBS cluster volume using the AWS EBS CSI driver.
2. Restart the current Swarm leader or trigger a leader election.
3. Schedule a service using an existing cluster volume.
4. Observe that Docker marks the volume as `in use`, while the EBS volume remains `available`.
5. Observe repeated node-side errors:

```text
publishing volume failed: rpc error: code = InvalidArgument desc = Device path not provided
```

Creating a new temporary CSI volume before scheduling the service also works around the issue because the create path initializes the CSI client and loads controller capabilities.

## Expected behavior

SwarmKit should initialize the CSI plugin before checking its controller capabilities.

When the driver supports `PUBLISH_UNPUBLISH_VOLUME`, `ControllerPublishVolume` should be called and its publish context should be passed to the node-side CSI operations.

## Testing

Tested with:

* Docker Engine 29.7.1
* Docker Swarm
* AWS EBS CSI driver
* Existing cluster volumes after a manager restart or leader change

Before this change, existing EBS volumes could become stuck in an inconsistent state:

```text
Docker: in use
AWS: available
```

After this change, the EBS volume is attached normally and the service starts successfully.
