### PR TITLE
manager/csi: add missing `nil` check in PublishVolume, UnpublishVolume

### DIFF
--- a/manager/csi/plugin.go
+++ b/manager/csi/plugin.go
@@ -208,6 +208,9 @@ func (p *plugin) DeleteVolume(ctx context.Context, v *api.Volume) error {
 // the Node with the given swarmkit ID. It returns a map, which is the
 // PublishContext for this Volume on this Node.
 func (p *plugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string) (map[string]string, error) {
+	if v.VolumeInfo == nil {
+		return nil, errors.New("VolumeInfo must not be nil")
+	}
 	if !p.publisher {
 		return nil, nil
 	}
@@ -234,6 +237,9 @@ func (p *plugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string
 // Volume from the Node with the given swarmkit ID. It returns an error if the
 // unpublish does not succeed
 func (p *plugin) UnpublishVolume(ctx context.Context, v *api.Volume, nodeID string) error {
+	if v.VolumeInfo == nil {
+		return errors.New("VolumeInfo must not be nil")
+	}
 	if !p.publisher {
 		return nil
 	}
@@ -315,34 +321,24 @@ func (p *plugin) makeSecrets(v *api.Volume) map[string]string {
 }
 
 func (p *plugin) makeControllerPublishVolumeRequest(v *api.Volume, nodeID string) *csi.ControllerPublishVolumeRequest {
-	if v.VolumeInfo == nil {
-		return nil
-	}
-
-	secrets := p.makeSecrets(v)
-	capability := capability.MakeCapability(v.Spec.AccessMode)
-	capability.AccessType = &csi.VolumeCapability_Mount{
+	csiCap := capability.MakeCapability(v.Spec.AccessMode)
+	csiCap.AccessType = &csi.VolumeCapability_Mount{
 		Mount: &csi.VolumeCapability_MountVolume{},
 	}
 	return &csi.ControllerPublishVolumeRequest{
 		VolumeId:         v.VolumeInfo.VolumeID,
 		NodeId:           p.swarmToCSI[nodeID],
-		Secrets:          secrets,
-		VolumeCapability: capability,
+		Secrets:          p.makeSecrets(v),
+		VolumeCapability: csiCap,
 		VolumeContext:    v.VolumeInfo.VolumeContext,
 	}
 }
 
 func (p *plugin) makeControllerUnpublishVolumeRequest(v *api.Volume, nodeID string) *csi.ControllerUnpublishVolumeRequest {
-	if v.VolumeInfo == nil {
-		return nil
-	}
-
-	secrets := p.makeSecrets(v)
 	return &csi.ControllerUnpublishVolumeRequest{
 		VolumeId: v.VolumeInfo.VolumeID,
 		NodeId:   p.swarmToCSI[nodeID],
-		Secrets:  secrets,
+		Secrets:  p.makeSecrets(v),
 	}
 }
 

--- a/manager/csi/plugin_test.go
+++ b/manager/csi/plugin_test.go
@@ -257,7 +257,6 @@ var _ = Describe("Plugin manager", func() {
 
 			request := plugin.makeControllerPublishVolumeRequest(v, "swarmNode1")
 
-			Expect(request).ToNot(BeNil())
 			Expect(request.VolumeId).To(Equal("volumePluginID1"))
 			Expect(request.NodeId).To(Equal("csiNode1"))
 			Expect(request.Secrets).To(SatisfyAll(
@@ -400,7 +399,6 @@ var _ = Describe("Plugin manager", func() {
 
 		It("should make a csi.ControllerUnpublishVolumeRequest for the given volume", func() {
 			request := plugin.makeControllerUnpublishVolumeRequest(v, "swarmNode1")
-			Expect(request).ToNot(BeNil())
 			Expect(request.VolumeId).To(Equal("volumePluginID1"))
 			Expect(request.NodeId).To(Equal("csiNode1"))
 			Expect(request.Secrets).To(SatisfyAll(


### PR DESCRIPTION
Both makeControllerPublishVolumeRequest and makeControllerUnpublishVolumeRequest check if the `VolumeInfo` is `nil`, in which case they would produce a `nil` request;

    func (p *plugin) makeControllerPublishVolumeRequest(v *api.Volume, nodeID string) *csi.ControllerPublishVolumeRequest {
        if v.VolumeInfo == nil {
            return nil
        }
        ...

    func (p *plugin) makeControllerUnpublishVolumeRequest(v *api.Volume, nodeID string) *csi.ControllerUnpublishVolumeRequest {
        if v.VolumeInfo == nil {
            return nil
        }
        ...

This request which would be sent to the CSI controller-client, potentially resulting in an obscure error during marshaling;

    rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil

Update `PublishVolume` and `UnpublishVolume` to return early, similar to the existing check in `DeleteVolume`;

    func (p *plugin) DeleteVolume(ctx context.Context, v *api.Volume) error {
        if v.VolumeInfo == nil {
            return errors.New("VolumeInfo must not be nil")
        }

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
